### PR TITLE
Pin nextjs to 16.0.7 for CVE-2025-66478

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@rainbow-me/rainbowkit": "^2.2.9",
     "@tanstack/react-query": "^5.90.10",
     "clsx": "^2.1.1",
-    "next": "16.0.3",
+    "next": "16.0.7",
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-hot-toast": "^2.6.0",


### PR DESCRIPTION
https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components