### PR TITLE
Add MOTD-driven stats bar messaging

### DIFF
--- a/app/api/motd/route.ts
+++ b/app/api/motd/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const url = process.env.NEXT_PUBLIC_MOTD_URL;
+  if (!url) {
+    return NextResponse.json(
+      { error: "NEXT_PUBLIC_MOTD_URL is not set" },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "Failed to fetch MOTD" },
+        { status: response.status }
+      );
+    }
+
+    const json = await response.json();
+    const cacheControl = response.headers.get("cache-control");
+    return NextResponse.json(json, {
+      headers: cacheControl ? { "Cache-Control": cacheControl } : undefined,
+    });
+  } catch (error) {
+    console.warn("MOTD proxy failed", error);
+    return NextResponse.json(
+      { error: "Failed to fetch MOTD" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/styfi/StyfiPageClient.tsx
+++ b/app/styfi/StyfiPageClient.tsx
@@ -9,6 +9,7 @@ import {
   useStyfiApy,
   useStyfiStats,
 } from "@/lib/hooks/useStyfi";
+import { useMotd } from "@/lib/hooks/useMotd";
 import { StyfiCockpit } from "./components/StyfiCockpit";
 import { AccountSummary } from "./components/AccountSummary";
 import type { StyfiAsset } from "./components/types";
@@ -72,6 +73,7 @@ function StyfiPageShell() {
   const { data: apy } = useStyfiApy();
   const { data: stats } = useStyfiStats();
   const { data: account, isLoading: isAccountLoading } = useStyfiAccount();
+  const { data: motd } = useMotd();
   const { globalData } = useProtocol();
   const { epochInfo } = useEpochClock({ tickMs: 60_000 });
   const [selectedAsset, setSelectedAsset] = useState<StyfiAsset>();
@@ -147,6 +149,11 @@ function StyfiPageShell() {
   const aprLabel = showProjectedApy
     ? copy.page.stats.aprEpoch1.label
     : copy.page.stats.apr.label;
+  const motdValue = motd?.styfi?.value?.trim();
+  const motdLabel = motd?.styfi?.label?.trim() || "State";
+  const motdItem = motdValue
+    ? { label: motdLabel, value: motdValue }
+    : null;
   const activeAsset = selectedAsset ?? "stYFIx";
   const balances = account ? deriveBalances(account) : null;
   const totalBalance = balances
@@ -172,10 +179,7 @@ function StyfiPageShell() {
             label: aprLabel,
             value: formattedApy,
           },
-          {
-            label: copy.page.stats.phase.label,
-            value: copy.page.stats.phase.value,
-          },
+          ...(motdItem ? [motdItem] : []),
         ]}
       />
 

--- a/app/styfi/messages.ts
+++ b/app/styfi/messages.ts
@@ -8,10 +8,6 @@ export const styfiCopy = {
     stats: {
       totalSupply: { label: "Total Supply" },
       staked: { label: "Staked" },
-      phase: {
-        label: "State",
-        value: "Staking live, voting coming soon",
-      },
       apr: { label: "APR" },
       aprEpoch1: { label: "Epoch 1 APR" },
     },

--- a/app/veyfi/components/VeyfiStatsBar.tsx
+++ b/app/veyfi/components/VeyfiStatsBar.tsx
@@ -2,11 +2,13 @@
 
 import { StatsBar } from "@/components/ui/StatsBar";
 import { useVeyfiStats } from "@/lib/hooks/useVeyfi";
+import { useMotd } from "@/lib/hooks/useMotd";
 import { formatTokenAmount, formatPercent } from "@/lib/format";
 import { veyfiCopy as copy } from "../messages";
 
 export function VeyfiStatsBar() {
   const { data: stats } = useVeyfiStats();
+  const { data: motd } = useMotd();
 
   let migratedLabel = "--";
   if (stats) {
@@ -27,16 +29,19 @@ export function VeyfiStatsBar() {
     ? formatPercent(stats.totalLlyfiStakedPercent, 1)
     : "--%";
 
+  const motdValue = motd?.veyfi?.value?.trim();
+  const motdLabel = motd?.veyfi?.label?.trim() || "State";
+  const motdItem = motdValue
+    ? { label: motdLabel, value: motdValue }
+    : null;
+
   return (
     <StatsBar
       items={[
         { label: copy.page.stats.migrated.label, value: migratedLabel },
         { label: copy.page.stats.boost.label, value: boostLabel },
         { label: copy.page.stats.staked.label, value: stakedLabel },
-        {
-          label: copy.page.stats.state.label,
-          value: copy.page.stats.state.value,
-        },
+        ...(motdItem ? [motdItem] : []),
       ]}
     />
   );

--- a/app/veyfi/messages.ts
+++ b/app/veyfi/messages.ts
@@ -7,7 +7,6 @@ export const veyfiCopy = {
       migrated: { label: "Migrated veYFI" },
       boost: { label: "Max Boost" },
       staked: { label: "LLYFI Staked" },
-      state: { label: "State", value: "Migration & Staking Open" },
     },
     connectBanner: {
       title: "Wallet not connected",

--- a/docs/10-veyfi-ui-spec.md
+++ b/docs/10-veyfi-ui-spec.md
@@ -51,7 +51,7 @@ Unlike the single-asset dashboard of stYFI, this is a **Registry & Management To
 - **Migrated veYFI:** Total amount + % of legacy supply migrated.
 - **Current Boost:** The current max multiplier (e.g., "1.52x") for legacy locks.
 - **Total Staked:** % of LLYFI supply currently staked in the protocol.
-- **State:** System phase (e.g., "Migration and staking open").
+- **State:** Optional system phase from MOTD JSON (`NEXT_PUBLIC_MOTD_URL`). Omit if missing/invalid.
 
 ### 4.2 Zone 1: Migration
 

--- a/docs/13-motd-schema.md
+++ b/docs/13-motd-schema.md
@@ -1,0 +1,51 @@
+# MOTD Schema (S3 JSON)
+
+This document defines the **optional** JSON schema served from S3 (or similar) and consumed by the frontend to render a per-app "State" message in the stats bar. The message can be updated without redeploying the frontend.
+
+- Env: `NEXT_PUBLIC_MOTD_URL`
+- Consumer: `useMotd()` / `lib/clients/motd.ts`
+- Refresh: 60s (React Query)
+- Failure behavior: if the JSON is missing/invalid/unreachable, the message is **not shown**.
+
+---
+
+## 1. JSON Shape
+
+```json
+{
+  "version": 1,
+  "styfi": {
+    "label": "State",
+    "value": "Staking live, voting coming soon"
+  },
+  "veyfi": {
+    "label": "State",
+    "value": "Migration & Staking Open"
+  }
+}
+```
+
+### Fields
+
+- `version` (required): Integer schema version (>= 1).
+- `styfi` (optional): Object containing a message for the stYFI app.
+- `veyfi` (optional): Object containing a message for the veYFI app.
+- `label` (optional): Defaults to `State` when omitted.
+- `value` (optional): If missing or empty, the message is not rendered.
+
+---
+
+## 2. Rendering Rules
+
+- If `value` is missing/empty -> do not render a message.
+- If `label` is missing/empty -> default to `State`.
+- This message is **app-specific** (stYFI vs veYFI).
+- The message is **informational only**; it does not gate any behavior.
+
+---
+
+## 3. Caching & Proxy
+
+- The browser uses `/api/motd` to avoid CORS issues.
+- Cache-control headers from the upstream response are forwarded by the proxy.
+- Default revalidation interval is 60 seconds.

--- a/docs/3-frd-frontend.md
+++ b/docs/3-frd-frontend.md
@@ -55,6 +55,15 @@ These apply across `/styfi` and `/veyfi`.
 
 ---
 
+## 2.1.1. Remote Stats Message (MOTD)
+
+1. The app **MAY** load a per-app stats bar message from a small S3 JSON blob (`NEXT_PUBLIC_MOTD_URL`).
+2. The message **MUST NOT** block render and **MUST** be ignored if the JSON is missing, invalid, or unreachable.
+3. If a `label` is missing, the UI **MUST** default to `State`.
+4. If `value` is missing/empty, the message **MUST NOT** render.
+
+---
+
 ## 2.2. Network Handling
 
 1. The app **MUST** enforce the correct network (Ethereum mainnet).

--- a/docs/4-architecture-blueprint.md
+++ b/docs/4-architecture-blueprint.md
@@ -253,6 +253,23 @@ This enables **first paint** of stats and inventory without a wallet connection 
 
 ---
 
+## 6.2 MOTD (S3)
+
+Per-app status text for the stats bar is fetched from a lightweight, versioned JSON blob:
+
+- Source: `NEXT_PUBLIC_MOTD_URL`
+- Validation: Zod schema in `lib/schemas/motd.ts`
+- Fetcher: `lib/clients/motd.ts` (returns `null` on failure). Uses a same-origin proxy route (`/api/motd`) in the browser to avoid CORS issues.
+- Hook: `lib/hooks/useMotd.ts` (React Query cache, 60s staleness)
+
+**Render rules:**
+
+- If `value` is missing/empty -> the message is not rendered.
+- If `label` is missing/empty -> default to `State`.
+- Messages are **per-app** (`styfi`, `veyfi`) and do not affect protocol behavior.
+
+---
+
 # 7. Hooks Layer
 
 All business logic lives in domain hooks.

--- a/docs/6-design-system.md
+++ b/docs/6-design-system.md
@@ -121,6 +121,7 @@ A full-width, slim informational strip.
 - **Purpose:** Display high-level ecosystem stats (e.g., Total Supply, Staked, APY).
 - **Styling:** `bg-neutral-100`, `border-b`, `py-2`.
 - **Typography:** Labels are uppercase/bold; values are `Aeonik Mono`.
+- **Behavior:** Optional message items (e.g., "State") may be injected via remote MOTD JSON; if missing, the bar renders without them.
 
 ### 4.7. `Badge`
 

--- a/docs/8-styfi-ui-spec.md
+++ b/docs/8-styfi-ui-spec.md
@@ -40,7 +40,7 @@ It specifically addresses:
 ## 3. Page Structure
 
 1. **Global Header** (standard Yearn header)
-2. **Protocol Stats Bar** (Total Supply, Staked, APR, State; show **“Epoch 1 APR”** when current epoch == 0 from the canonical clock). **Staked** should use `styfi.staked` (excludes cooldown balances; `styfi.unstaking` is the cooldown amount).
+2. **Protocol Stats Bar** (Total Supply, Staked, APR, optional State). Show **"Epoch 1 APR"** when current epoch == 0 from the canonical clock. **Staked** should use `styfi.staked` (excludes cooldown balances; `styfi.unstaking` is the cooldown amount). The **State** item is sourced from the MOTD JSON (`NEXT_PUBLIC_MOTD_URL`) and is omitted if missing/invalid.
 3. **AccountSummary** (Hero for new users, positions list for returning users)
 4. **Cockpit** (StakeManageCard + Rewards)
 

--- a/docs/9-frontend-architecture.md
+++ b/docs/9-frontend-architecture.md
@@ -205,7 +205,13 @@ Under `/lib/hooks/useStyfi.ts`:
    - Source: canonical epoch clock (latest block timestamp when connected, else S3 `meta.timestamp`, else local time).
    - Returns: `currentEpoch`, `epochStart`, `epochEnd`.
 
-5. Transaction flows use:
+5. `useMotd()`
+
+   - **Shared hook** for optional stats-bar messaging.
+   - Source: S3 JSON (`NEXT_PUBLIC_MOTD_URL`) via `/api/motd` proxy in the browser.
+   - Returns: per-app label/value; missing or invalid data is ignored.
+
+6. Transaction flows use:
    - `prepareStake`, `prepareStartCooldown`, `prepareWithdraw`, `prepareClaimRewards`
    - `useTx()` from `/lib/tx/useTx.ts`
 
@@ -213,7 +219,7 @@ Under `/lib/hooks/useStyfi.ts`:
 
 Each card/component uses **only the hooks it needs**:
 
-- `StyfiPageClient` → `useStyfiStats`, `useStyfiApy` (for StatsBar).
+- `StyfiPageClient` → `useStyfiStats`, `useStyfiApy`, `useMotd` (for StatsBar).
 - `AccountSummary` → `useStyfiAccount`.
 - `RewardsCard` → `useStyfiAccount`, `useStyfiApy`, `useRewardTokenInfo`.
 - `StakeTab` → `useStyfiAccount` (wallet balance) + `prepareStake`.
@@ -254,7 +260,7 @@ We do **not** block the entire `/styfi` route on a single slow query.
 /veyfi
   ├── Global Header
   └── VeyfiPageClient
-       ├─ [VeyfiStatsBar]       (Ecosystem health: Migration %, Boost, Staked %)
+       ├─ [VeyfiStatsBar]       (Ecosystem health: Migration %, Boost, Staked %, optional State)
        └─ Main Container
             ├─ [MigrationCard]        (Conditionally visible: Action vs Info)
             ├─ [LlyfiTokenTable]      (The Ledger)
@@ -317,6 +323,11 @@ Under `/lib/hooks/useVeyfi.ts`:
 4.  `useLlyfiTokens()`
     - Selector on `useVeyfiAccount`.
     - Used by: `LlyfiTokenTable`.
+
+5.  `useMotd()`
+
+    - Shared hook for optional stats-bar messaging.
+    - Used by: `VeyfiStatsBar`.
 
 ### 9.4 State Management
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ They define **what the frontend must do** and **how it is built**, and serve as 
 - [**10-veyfi-ui-spec.md**](10-veyfi-ui-spec.md) — veYFI UI spec
 - [**11-testing.md**](11-testing.md) — Testing strategy, infrastructure, and workflow
 - [**12-global-data-schema.md**](12-global-data-schema.md) — S3 JSON schema for global (pre‑wallet) data
+- [**13-motd-schema.md**](13-motd-schema.md) — S3 JSON schema for per-app stats bar messages
 - [**dev-mock-toggles.md**](dev-mock-toggles.md) — Mock scenarios and time offset for local UI testing
 
 ## Usage
@@ -42,6 +43,7 @@ Minimum env vars for non‑mock runs:
 
 Optional:
 
+- `NEXT_PUBLIC_MOTD_URL` — S3 (or similar) JSON for per-app stats bar messages.
 - `NEXT_PUBLIC_RPC_URLS` — Comma‑separated RPC URLs (used for dev/fork transports).
 - `NEXT_PUBLIC_USE_MOCKS=true` — Forces mock clients.
 - `NEXT_PUBLIC_E2E=true` — Enables Test Bridge + mock wallet for Playwright.

--- a/lib/clients/motd.ts
+++ b/lib/clients/motd.ts
@@ -1,0 +1,43 @@
+import { MotdSchema, type Motd } from "@/lib/schemas/motd";
+
+const MOTD_URL = process.env.NEXT_PUBLIC_MOTD_URL;
+const MOTD_PROXY = "/api/motd";
+
+async function fetchAndValidate(url: string, label: string) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    console.warn(`MOTD fetch failed (${label}):`, response.status);
+    return null;
+  }
+  const json = await response.json();
+  const parsed = MotdSchema.safeParse(json);
+  if (!parsed.success) {
+    console.warn(`MOTD schema validation failed (${label})`, parsed.error);
+    return null;
+  }
+  return parsed.data;
+}
+
+export async function fetchMotd(): Promise<Motd | null> {
+  if (!MOTD_URL) return null;
+
+  try {
+    const preferProxy = typeof window !== "undefined";
+    const primary = preferProxy ? MOTD_PROXY : MOTD_URL;
+    const secondary = preferProxy ? MOTD_URL : MOTD_PROXY;
+
+    const primaryData = await fetchAndValidate(
+      primary,
+      preferProxy ? "proxy" : "direct"
+    );
+    if (primaryData) return primaryData;
+
+    return await fetchAndValidate(
+      secondary,
+      preferProxy ? "direct" : "proxy"
+    );
+  } catch (error) {
+    console.warn("Failed to fetch MOTD", error);
+    return null;
+  }
+}

--- a/lib/hooks/useMotd.ts
+++ b/lib/hooks/useMotd.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { fetchMotd } from "@/lib/clients/motd";
+
+export function useMotd() {
+  return useQuery({
+    queryKey: ["motd"],
+    queryFn: fetchMotd,
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+  });
+}

--- a/lib/schemas/motd.ts
+++ b/lib/schemas/motd.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const MotdSchema = z.object({
+  version: z.number().int().min(1),
+  styfi: z
+    .object({
+      label: z.string().optional(),
+      value: z.string().optional(),
+    })
+    .optional(),
+  veyfi: z
+    .object({
+      label: z.string().optional(),
+      value: z.string().optional(),
+    })
+    .optional(),
+});
+
+export type Motd = z.infer<typeof MotdSchema>;


### PR DESCRIPTION
- add MOTD schema, client fetcher, React Query hook, and /api/motd proxy with cache passthrough
- wire optional per-app MOTD message into stYFI and veYFI stats bars with safe fallback
- remove hardcoded state copy from stYFI/veYFI messages
- document MOTD behavior and config across FRD, architecture, UI specs, design system, and README