### PR TITLE
fix(veyfi): Fix stYFI dashboard CTA link resolution

### DIFF
--- a/app/veyfi/components/VeyfiRewardsCard.tsx
+++ b/app/veyfi/components/VeyfiRewardsCard.tsx
@@ -1,11 +1,30 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
 import { veyfiCopy as copy } from "../messages";
 
+const STYFI_DASHBOARD_HOST = "styfi.yearn.fi";
+const VEYFI_HOST = "veyfi.yearn.fi";
+
+function resolveStyfiDashboardHref(hostname?: string) {
+  if (!hostname) return "/styfi";
+  const host = hostname.toLowerCase();
+  if (host === VEYFI_HOST) {
+    return `https://${STYFI_DASHBOARD_HOST}`;
+  }
+  return "/styfi";
+}
+
 export function VeyfiRewardsCard() {
+  const [styfiHref, setStyfiHref] = useState("/styfi");
+
+  useEffect(() => {
+    setStyfiHref(resolveStyfiDashboardHref(window.location.hostname));
+  }, []);
+
   return (
     <Card className="h-full flex flex-col justify-between space-y-6">
       <div className="space-y-4">
@@ -18,7 +37,7 @@ export function VeyfiRewardsCard() {
         <p className="text-sm text-neutral-600">{copy.rewards.helper}</p>
       </div>
       <div className="pt-4 border-t border-neutral-100">
-        <Link href="/styfi" className="block w-full">
+        <Link href={styfiHref} className="block w-full">
           <Button variant="veyfi" className="w-full">
             {copy.rewards.linkCta}
           </Button>


### PR DESCRIPTION
- resolve the rewards CTA href based on hostname to target styfi.yearn.fi when served from veyfi.yearn.fi
- keep the relative /styfi link for default hosts and local development to preserve internal routing