### PR TITLE
fix(veyfi): correct 1UP/supYFI labeling, stabilize locker boost, and harden RPC fallback paths

### DIFF
--- a/app/veyfi/components/InventoryCard.tsx
+++ b/app/veyfi/components/InventoryCard.tsx
@@ -5,6 +5,7 @@ import { useVeyfiStats } from "@/lib/hooks/useVeyfi";
 import { formatTokenAmount, formatPercent } from "@/lib/format";
 import { veyfiCopy as copy } from "../messages";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function InventoryCard() {
   const { data: stats, isLoading } = useVeyfiStats();
@@ -62,7 +63,7 @@ export function InventoryCard() {
             {stats.tokens.map((token) => (
               <tr key={token.symbol}>
                 <td className="px-6 py-4 font-medium text-neutral-700">
-                  {token.symbol}
+                  {getLlyfiDisplaySymbol(token.symbol)}
                 </td>
                 <td className="px-6 py-4 text-right font-number text-neutral-900">
                   {/* Standardize to 2 decimals */}

--- a/app/veyfi/components/LlyfiTokenRow.tsx
+++ b/app/veyfi/components/LlyfiTokenRow.tsx
@@ -13,16 +13,14 @@ import { useProtocol } from "@/state/protocol";
 import { useIdentity } from "@/state/identity";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useEpochClock } from "@/lib/hooks/useEpochClock";
-import { useVeyfiAccount } from "@/lib/hooks/useVeyfi";
-import { getVeyfiBoostMultiplier } from "@/lib/clients/veyfi/boost";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function LlyfiTokenRow({ token }: { token: LlyfiTokenState }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const { data: baseApyBps } = useStyfiApy();
   const { globalData } = useProtocol();
   const { isConnected } = useIdentity();
-  const { epochInfo, now } = useEpochClock({ tickMs: 60_000 });
-  const { data: veyfiAccount } = useVeyfiAccount();
+  const { epochInfo } = useEpochClock({ tickMs: 60_000 });
 
   const toNumber = (value?: string | number | null) => {
     if (value === null || value === undefined) return null;
@@ -51,6 +49,8 @@ export function LlyfiTokenRow({ token }: { token: LlyfiTokenState }) {
     }
     return formatPercent(value, maximumFractionDigits);
   };
+
+  const displaySymbol = getLlyfiDisplaySymbol(token.symbol);
 
   // --- Derived Metrics ---
   const staked = token.stakedBalance + token.cooldownBalance;
@@ -95,12 +95,8 @@ export function LlyfiTokenRow({ token }: { token: LlyfiTokenState }) {
       : formatPercent(utilizationRatioRaw, 1);
 
   const maxBoostBps = toNumber(globalData?.global?.maxBoostBps);
-  const accountBoost = veyfiAccount?.veYfi
-    ? getVeyfiBoostMultiplier(veyfiAccount.veYfi.unlockTime, now)
-    : null;
   const boostMultiplier =
-    accountBoost ??
-    (maxBoostBps !== null ? maxBoostBps / 10000 : token.veyfiBoost || 1);
+    maxBoostBps !== null ? maxBoostBps / 10000 : token.veyfiBoost || 1;
 
   const isEpochZero = epochInfo?.currentEpoch === 0;
   const s3EffectiveAprBps = s3Llyfi
@@ -200,7 +196,7 @@ export function LlyfiTokenRow({ token }: { token: LlyfiTokenState }) {
         <div className="font-bold text-neutral-900">
           {token.name}{" "}
           <span className="text-neutral-500 font-normal ml-1">
-            ({token.symbol})
+            ({displaySymbol})
           </span>
         </div>
 

--- a/app/veyfi/components/MockControls.tsx
+++ b/app/veyfi/components/MockControls.tsx
@@ -11,6 +11,7 @@ import { useProtocol } from "@/state/protocol";
 import { toast } from "@/components/ui/Toast";
 import { DebugControls } from "@/components/DebugControls";
 import { LlyfiTokenId } from "@/lib/clients/veyfi";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function MockControls() {
   const queryClient = useQueryClient();
@@ -39,7 +40,9 @@ export function MockControls() {
         await queryClient.invalidateQueries({
           queryKey: veyfiKeys.account(address),
         });
-        toast.success(`Added ${amount / 10n ** 18n} ${symbol}`);
+        toast.success(
+          `Added ${amount / 10n ** 18n} ${getLlyfiDisplaySymbol(symbol)}`
+        );
       } else {
         toast.error("Connect wallet first");
       }
@@ -95,7 +98,7 @@ export function MockControls() {
           className="col-span-2"
           onClick={() => handleInjectLlyfi("upYFI", 10000n * 10n ** 18n)}
         >
-          +10,000 upYFI
+          +10,000 {getLlyfiDisplaySymbol("upYFI")}
         </Button>
       </div>
     </DebugControls>

--- a/app/veyfi/components/VeyfiRewardsCard.tsx
+++ b/app/veyfi/components/VeyfiRewardsCard.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
@@ -19,11 +18,9 @@ function resolveStyfiDashboardHref(hostname?: string) {
 }
 
 export function VeyfiRewardsCard() {
-  const [styfiHref, setStyfiHref] = useState("/styfi");
-
-  useEffect(() => {
-    setStyfiHref(resolveStyfiDashboardHref(window.location.hostname));
-  }, []);
+  const styfiHref = resolveStyfiDashboardHref(
+    typeof window === "undefined" ? undefined : window.location.hostname
+  );
 
   return (
     <Card className="h-full flex flex-col justify-between space-y-6">

--- a/app/veyfi/components/tabs/LlyfiStakeTab.tsx
+++ b/app/veyfi/components/tabs/LlyfiStakeTab.tsx
@@ -12,6 +12,7 @@ import { formatInputAmount, formatTokenAmount } from "@/lib/format";
 import { parseAmount } from "@/lib/parse";
 import { LlyfiTokenState } from "@/lib/clients/veyfi";
 import { toast } from "@/components/ui/Toast";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function LlyfiStakeTab({ token }: { token: LlyfiTokenState }) {
   const { isConnected, address } = useIdentity();
@@ -19,6 +20,7 @@ export function LlyfiStakeTab({ token }: { token: LlyfiTokenState }) {
   const [input, setInput] = useState("");
 
   const { amount, isValid } = useMemo(() => parseAmount(input), [input]);
+  const displaySymbol = getLlyfiDisplaySymbol(token.symbol);
   const scale = token.exchangeRate > 0n ? token.exchangeRate : 1n;
   const roundedAmount = isValid ? amount - (amount % scale) : 0n;
   const effectiveAmount = isValid ? roundedAmount : 0n;
@@ -70,9 +72,7 @@ export function LlyfiStakeTab({ token }: { token: LlyfiTokenState }) {
     await stake(token.symbol, effectiveAmount);
     setInput("");
     toast.success(
-      `Successfully staked ${formatTokenAmount(effectiveAmount)} ${
-        token.symbol
-      }`
+      `Successfully staked ${formatTokenAmount(effectiveAmount)} ${displaySymbol}`
     );
   };
 
@@ -86,10 +86,10 @@ export function LlyfiStakeTab({ token }: { token: LlyfiTokenState }) {
         value={input}
         onChange={setInput}
         maxLabel={`Balance: ${formatTokenAmount(token.walletBalance)} ${
-          token.symbol
+          displaySymbol
         }`}
         onMaxClick={handleMaxClick}
-        tokenSymbol={token.symbol}
+        tokenSymbol={displaySymbol}
         error={
           !isSubmitting && insufficientBalance
             ? "Insufficient balance"
@@ -111,7 +111,7 @@ export function LlyfiStakeTab({ token }: { token: LlyfiTokenState }) {
             }
             isLoading={approveLoading}
           >
-            Approve {token.symbol}
+            Approve {displaySymbol}
           </Button>
         ) : (
           <Button
@@ -120,7 +120,7 @@ export function LlyfiStakeTab({ token }: { token: LlyfiTokenState }) {
             disabled={isDisabled}
             isLoading={isSubmitting}
           >
-            Stake {token.symbol}
+            Stake {displaySymbol}
           </Button>
         )}
       </div>

--- a/app/veyfi/components/tabs/LlyfiTradeTab.tsx
+++ b/app/veyfi/components/tabs/LlyfiTradeTab.tsx
@@ -18,6 +18,7 @@ import { parseAmount } from "@/lib/parse";
 import { LlyfiTokenState } from "@/lib/clients/veyfi";
 import { RadioGroup } from "@/components/ui/RadioGroup";
 import { YFI_ADDRESS, SPENDER_REDEMPTION } from "@/lib/constants";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function LlyfiTradeTab({ token }: { token: LlyfiTokenState }) {
   const { isConnected, yfiBalance, isBlacklisted, address } = useIdentity();
@@ -45,8 +46,9 @@ export function LlyfiTradeTab({ token }: { token: LlyfiTokenState }) {
 
   const isSell = mode === "sell";
   const userBalance = isSell ? token.walletBalance : yfiBalance;
-  const sourceSymbol = isSell ? token.symbol : "YFI";
-  const targetSymbol = isSell ? "YFI" : token.symbol;
+  const displaySymbol = getLlyfiDisplaySymbol(token.symbol);
+  const sourceSymbol = isSell ? displaySymbol : "YFI";
+  const targetSymbol = isSell ? "YFI" : displaySymbol;
 
   const exchangeRate = token.exchangeRate;
   const ONE_E18 = 10n ** 18n;
@@ -160,8 +162,8 @@ export function LlyfiTradeTab({ token }: { token: LlyfiTokenState }) {
           value={mode}
           onChange={setMode}
           options={[
-            { value: "sell", label: `Sell ${token.symbol}` },
-            { value: "buy", label: `Buy ${token.symbol}` },
+            { value: "sell", label: `Sell ${displaySymbol}` },
+            { value: "buy", label: `Buy ${displaySymbol}` },
           ]}
         />
       </div>
@@ -227,7 +229,7 @@ export function LlyfiTradeTab({ token }: { token: LlyfiTokenState }) {
               }
             }}
           >
-            {isSell ? `Sell ${token.symbol}` : `Buy ${token.symbol}`}
+            {isSell ? `Sell ${displaySymbol}` : `Buy ${displaySymbol}`}
           </Button>
         )}
       </div>

--- a/app/veyfi/components/tabs/LlyfiUnstakeTab.tsx
+++ b/app/veyfi/components/tabs/LlyfiUnstakeTab.tsx
@@ -7,12 +7,14 @@ import { useLlyfiStartCooldown, useLlyfiWithdraw } from "@/lib/hooks/useVeyfi";
 import { parseAmount } from "@/lib/parse";
 import { formatInputAmount } from "@/lib/format";
 import { UnstakePanel } from "@/components/domain/UnstakePanel";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function LlyfiUnstakeTab({ token }: { token: LlyfiTokenState }) {
   const { isConnected } = useIdentity();
   const [input, setInput] = useState("");
 
   const { amount, isValid } = useMemo(() => parseAmount(input), [input]);
+  const displaySymbol = getLlyfiDisplaySymbol(token.symbol);
   const scale = token.exchangeRate > 0n ? token.exchangeRate : 1n;
   const roundedAmount = isValid ? amount - (amount % scale) : 0n;
   const effectiveAmount = isValid ? roundedAmount : 0n;
@@ -54,7 +56,7 @@ export function LlyfiUnstakeTab({ token }: { token: LlyfiTokenState }) {
     <div className="max-w-xl">
       <UnstakePanel
         variant="veyfi"
-        tokenSymbol={token.symbol}
+        tokenSymbol={displaySymbol}
         availableBalance={token.stakedBalance}
         totalExiting={totalExiting}
         liquidEstimate={liquidAssets}

--- a/lib/clients/styfi/onchain.ts
+++ b/lib/clients/styfi/onchain.ts
@@ -89,6 +89,51 @@ export class OnchainStyfiClient implements StyfiClient {
     return localNow;
   }
 
+  private buildFallbackAccountState(
+    address: Address,
+    nowSecondsValue: number
+  ): StyfiAccountState {
+    const { currentEpoch, epochEnd } = getEpochInfoFromGenesis(
+      GENESIS,
+      EPOCH_LENGTH,
+      nowSecondsValue
+    );
+
+    return {
+      address,
+      isBlacklisted: false,
+      yfiBalance: 0n,
+      styfiActive: 0n,
+      styfiInCooldown: 0n,
+      styfiUnlocked: 0n,
+      styfiWithdrawable: 0n,
+      styfiCooldown: null,
+      styfiX: {
+        sharesActive: 0n,
+        sharesInCooldown: 0n,
+        assetsActive: 0n,
+        assetsInCooldown: 0n,
+        assetsUnlocked: 0n,
+        assetsWithdrawable: 0n,
+        cooldown: null,
+      },
+      claimableGenericRewards: 0n,
+      claimableBoostedRewards: 0n,
+      accruingGenericRewards: 0n,
+      accruingBoostedRewards: 0n,
+      allowances: {
+        yfiToStyfi: 0n,
+        yfiToStyfiX: 0n,
+      },
+      epoch: {
+        currentEpoch,
+        epochEnd,
+        nextEpochStart: epochEnd,
+      },
+      rewardToken: REWARD_TOKEN_CONFIG,
+    };
+  }
+
   async getAccountState(address: Address): Promise<StyfiAccountState> {
     if (!this.publicClient) {
       throw new Error("Wallet public client not available");
@@ -238,9 +283,9 @@ export class OnchainStyfiClient implements StyfiClient {
           decimals: rewardTokenDecimals,
         },
       };
-    } catch (error) {
-      console.error("Critical error fetching account state:", error);
-      throw error;
+    } catch {
+      console.warn("Failed to fetch stYFI account state; using fallback data.");
+      return this.buildFallbackAccountState(address, nowSeconds());
     }
   }
 

--- a/lib/clients/veyfi/display.ts
+++ b/lib/clients/veyfi/display.ts
@@ -1,0 +1,7 @@
+const LLYFI_DISPLAY_SYMBOL_OVERRIDES: Record<string, string> = {
+  upYFI: "supYFI",
+};
+
+export function getLlyfiDisplaySymbol(symbol: string): string {
+  return LLYFI_DISPLAY_SYMBOL_OVERRIDES[symbol] ?? symbol;
+}

--- a/lib/clients/veyfi/onchain.ts
+++ b/lib/clients/veyfi/onchain.ts
@@ -345,8 +345,8 @@ export class OnchainVeyfiClient implements VeyfiClient {
           feeBps: Number(redemptionGlobalFee) / 10 ** 14,
         },
       };
-    } catch (error) {
-      console.error("Error fetching veYFI account state:", error);
+    } catch {
+      console.warn("Failed to fetch veYFI account state; using fallback data.");
       return {
         address,
         veYfi: null,
@@ -520,13 +520,22 @@ export class OnchainVeyfiClient implements VeyfiClient {
       const now = await this.getCanonicalNowSeconds();
       const currentEpoch = getCurrentEpoch(GENESIS, EPOCH_LENGTH, now);
       const currentEpochArg = BigInt(currentEpoch);
-
-      const totalWeightResult = await this.publicClient.readContract({
-        address: VEYFI_REWARD_DISTRIBUTOR_ADDRESS,
-        abi: VotingEscrowRewardDistributorAbi,
-        functionName: "total_weights",
-        args: [currentEpochArg],
-      });
+      let migratedUnderlyingApprox = 0n;
+      if (currentEpoch > 0) {
+        try {
+          const totalWeightResult = await this.publicClient.readContract({
+            address: VEYFI_REWARD_DISTRIBUTOR_ADDRESS,
+            abi: VotingEscrowRewardDistributorAbi,
+            functionName: "total_weights",
+            args: [currentEpochArg],
+          });
+          migratedUnderlyingApprox = totalWeightResult.slope * 104n;
+        } catch {
+          console.warn(
+            "Failed to read veYFI total weights for current epoch; continuing with fallback migrated amount."
+          );
+        }
+      }
 
       const calls = [
         {
@@ -583,8 +592,6 @@ export class OnchainVeyfiClient implements VeyfiClient {
         contracts: calls,
         allowFailure: false,
       });
-
-      const migratedUnderlyingApprox = totalWeightResult.slope * 104n;
 
       const lockedYfi = results[0] as bigint;
       const fee = results[1] as bigint;
@@ -650,8 +657,8 @@ export class OnchainVeyfiClient implements VeyfiClient {
         },
         tokens,
       };
-    } catch (e) {
-      console.error("Failed to fetch veYFI global stats:", e);
+    } catch {
+      console.warn("Failed to fetch veYFI global stats; using fallback data.");
       return {
         migratedYfi: 0n,
         lockedYfi: 0n,


### PR DESCRIPTION

- Preserve the locker protocol name as `1UP` while correcting the displayed token ticker from `upYFI` to `supYFI`.
- Add a centralized veYFI display-symbol override helper and apply it consistently across:
- LLYFI token table row symbol rendering
- Redemption inventory table asset labels
- Trade tab buy/sell labels and action buttons
- Stake/unstake input symbols and action labels
- veYFI mock controls labels and toast messaging
- Remove wallet/account-derived boost substitution in LLYFI row rendering and keep locker boost display sourced from global/S3 boost data to prevent connected-state regressions to `1.0x`.
- Harden veYFI onchain global stats reads by avoiding `total_weights` calls at epoch `0` and gracefully falling back when that read fails.
- Convert failing onchain account/global fetch paths in veYFI and stYFI clients from hard error propagation to warning + safe fallback data, reducing user-facing RPC error noise and preserving UI availability during upstream instability.
- Resolve the lint violation in `VeyfiRewardsCard` (`react-hooks/set-state-in-effect`) by replacing effect-driven state initialization with direct deterministic href resolution.

Validation:
- `npm run typecheck`
- `npm run lint`
- `npm test`