### PR TITLE
fix(header): correct stYFI/veYFI branding links across host- and path-based routes

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSelectedLayoutSegments } from "next/navigation";
 import { AppLauncher } from "@/components/AppLauncher";
 import { WalletButton } from "@/components/WalletButton";
 import { cn } from "@/lib/cn";
@@ -12,25 +12,28 @@ import { useEpochClock } from "@/lib/hooks/useEpochClock";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useGlobalData } from "@/lib/hooks/useGlobalData";
 import { useProtocol } from "@/state/protocol";
+import { resolveHeaderPrimaryNav } from "@/lib/header-nav";
 
 export function Header() {
   const pathname = usePathname();
+  const segments = useSelectedLayoutSegments();
+  const segment = segments[0] ?? null;
   const clock = useEpochClock({ tickMs: 1000 });
   const { isLoading: isGlobalLoading } = useGlobalData();
   const { publicClient } = useProtocol();
   const showEpochPill = !!publicClient || !isGlobalLoading;
 
   const navItems = useMemo(() => {
-    const isVeyfi = pathname?.startsWith("/veyfi");
+    const primaryNav = resolveHeaderPrimaryNav(pathname, segment);
     return [
       {
-        label: isVeyfi ? "veYFI" : "stYFI",
-        href: isVeyfi ? "/veyfi" : "/styfi",
+        label: primaryNav.label,
+        href: primaryNav.path,
         variant: "primary" as const,
       },
       ...appCopy.nav.items.filter((i) => i.variant !== "primary"),
     ];
-  }, [pathname]);
+  }, [pathname, segment]);
 
   return (
     <header className="sticky top-0 z-40 w-full border-b border-border bg-app/80 backdrop-blur-md">

--- a/lib/header-nav.ts
+++ b/lib/header-nav.ts
@@ -1,0 +1,43 @@
+const APP_NAV = {
+  styfi: { label: "stYFI", path: "/styfi" },
+  veyfi: { label: "veYFI", path: "/veyfi" },
+} as const;
+
+type AppKey = keyof typeof APP_NAV;
+
+function isAppKey(value: string | null): value is AppKey {
+  return value === "styfi" || value === "veyfi";
+}
+
+function resolveAppKey(pathname: string | null, segment: string | null): AppKey | null {
+  const normalizedSegment = segment?.toLowerCase() ?? null;
+  if (isAppKey(normalizedSegment)) {
+    return normalizedSegment;
+  }
+
+  const normalizedPathname = pathname?.toLowerCase() ?? "";
+  if (normalizedPathname.startsWith(APP_NAV.veyfi.path)) {
+    return "veyfi";
+  }
+  if (normalizedPathname.startsWith(APP_NAV.styfi.path)) {
+    return "styfi";
+  }
+
+  return null;
+}
+
+export function resolveHeaderPrimaryNav(pathname: string | null, segment: string | null) {
+  const appKey = resolveAppKey(pathname, segment);
+  if (!appKey) {
+    return APP_NAV.styfi;
+  }
+
+  const app = APP_NAV[appKey];
+  const normalizedPathname = pathname?.toLowerCase() ?? "";
+  const isPathScoped = normalizedPathname.startsWith(app.path);
+
+  return {
+    label: app.label,
+    path: isPathScoped ? app.path : "/",
+  };
+}

--- a/tests/unit/lib/header-nav.test.ts
+++ b/tests/unit/lib/header-nav.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveHeaderPrimaryNav } from "@/lib/header-nav";
+
+describe("resolveHeaderPrimaryNav", () => {
+  it("resolves branded stYFI host routes to root nav href", () => {
+    expect(resolveHeaderPrimaryNav("/", "styfi")).toEqual({
+      label: "stYFI",
+      path: "/",
+    });
+  });
+
+  it("resolves branded veYFI host routes to root nav href", () => {
+    expect(resolveHeaderPrimaryNav("/", "veyfi")).toEqual({
+      label: "veYFI",
+      path: "/",
+    });
+  });
+
+  it("keeps path-scoped stYFI routes for shared hosts", () => {
+    expect(resolveHeaderPrimaryNav("/styfi", "styfi")).toEqual({
+      label: "stYFI",
+      path: "/styfi",
+    });
+  });
+
+  it("keeps path-scoped veYFI routes for shared hosts", () => {
+    expect(resolveHeaderPrimaryNav("/veyfi", "veyfi")).toEqual({
+      label: "veYFI",
+      path: "/veyfi",
+    });
+  });
+
+  it("falls back to pathname when segment is unavailable", () => {
+    expect(resolveHeaderPrimaryNav("/veyfi/portfolio", null)).toEqual({
+      label: "veYFI",
+      path: "/veyfi",
+    });
+  });
+
+  it("falls back to default nav on launcher route", () => {
+    expect(resolveHeaderPrimaryNav("/", null)).toEqual({
+      label: "stYFI",
+      path: "/styfi",
+    });
+  });
+});

--- a/types/next-shim.d.ts
+++ b/types/next-shim.d.ts
@@ -31,6 +31,12 @@ declare module "next/link" {
 
 declare module "next/navigation" {
   export function usePathname(): string | null;
+  export function useSelectedLayoutSegment(
+    parallelRouteKey?: string
+  ): string | null;
+  export function useSelectedLayoutSegments(
+    parallelRouteKey?: string
+  ): string[];
   export function useRouter(): unknown;
   export function useSearchParams(): URLSearchParams;
 }


### PR DESCRIPTION
- Reworked header primary navigation resolution to use app context instead of pathname-only checks.
- Added a dedicated resolver that determines the active app from layout segment first, with pathname fallback for compatibility.
- Corrected branded-domain behavior so:
  - styfi.yearn.fi shows "stYFI" and links to "/"
  - veyfi.yearn.fi shows "veYFI" and links to "/"
- Preserved shared-host path behavior so:
  - app.dao-ops.com/styfi links to "/styfi"
  - app.dao-ops.com/veyfi links to "/veyfi"
- Added targeted unit coverage for branded root routes, shared path routes, fallback resolution, and launcher defaults.
- Updated local Next navigation type declarations to include selected-layout hooks used by the header logic.

Validation:
- npm run typecheck
- npm run lint
- npm test -- tests/unit/lib/header-nav.test.ts tests/components/UnstakePanel.test.tsx