### PR TITLE
feat(banners): add cross-app smart nudge system with lightweight read…

### DIFF
--- a/app/_shared/messages.ts
+++ b/app/_shared/messages.ts
@@ -11,3 +11,31 @@ export const appCopy = {
     },
   },
 } as const;
+
+export const crossAppNudgeCopy = {
+  shared: {
+    cta: {
+      toVeyfi: "Visit veYFI website",
+      toStyfi: "Visit stYFI website",
+    },
+  },
+  styfiPage: {
+    migration: {
+      title: "Legacy veYFI lock detected",
+      body: (legacyAmount: string) =>
+        `${legacyAmount} veYFI is eligible for migration. Migrate and earn boosted rewards.`,
+    },
+    unstakedLlyfi: {
+      title: "Unstaked liquid locker tokens detected",
+      body: (tokenList: string) => `In wallet: ${tokenList}. Stake to earn rewards.`,
+      fallback: "Stake your liquid locker positions to earn rewards.",
+    },
+  },
+  veyfiPage: {
+    unstakedYfi: {
+      title: "Unstaked YFI detected",
+      body: (yfiAmount: string) =>
+        `${yfiAmount} YFI is available to stake into stYFI or stYFIx.`,
+    },
+  },
+} as const;

--- a/app/styfi/StyfiPageClient.tsx
+++ b/app/styfi/StyfiPageClient.tsx
@@ -19,6 +19,9 @@ import { useProtocol } from "@/state/protocol";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { StyfiAccountState } from "@/lib/clients/styfi/types";
 import { useEpochClock } from "@/lib/hooks/useEpochClock";
+import { CrossAppNudge } from "@/components/domain/CrossAppNudge";
+import { useCrossChainNudge } from "@/lib/hooks/useCrossChainNudge";
+import { scrollToTargetWhenReady } from "@/lib/scrollToTarget";
 
 function deriveBalances(account: StyfiAccountState) {
   const styfiActive = account.styfiActive;
@@ -56,18 +59,22 @@ function deriveBalances(account: StyfiAccountState) {
   };
 }
 
-export function StyfiPageClient() {
+type StyfiPageClientProps = {
+  hostname?: string | null;
+};
+
+export function StyfiPageClient({ hostname }: StyfiPageClientProps) {
   const { usesMockBackend } = useProtocol();
 
   return (
     <>
-      <StyfiPageShell />
+      <StyfiPageShell hostname={hostname} />
       {usesMockBackend && <MockControls />}
     </>
   );
 }
 
-function StyfiPageShell() {
+function StyfiPageShell({ hostname }: StyfiPageClientProps) {
   const { isConnected } = useIdentity();
   const { openConnectModal } = useConnectModal();
   const { data: apy } = useStyfiApy();
@@ -80,6 +87,10 @@ function StyfiPageShell() {
   const hasUserSelected = useRef(false);
   const hasResolvedDefault = useRef(false);
   const cockpitRef = useRef<HTMLDivElement>(null);
+  const { nudge, dismiss } = useCrossChainNudge({
+    currentApp: "styfi",
+    hostname,
+  });
 
   const handleSelectAsset = useCallback((asset: StyfiAsset) => {
     hasUserSelected.current = true;
@@ -118,6 +129,24 @@ function StyfiPageShell() {
     }
     hasResolvedDefault.current = true;
   }, [account]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const search = new URLSearchParams(window.location.search);
+    const focus = search.get("focus");
+    const hash = window.location.hash.replace(/^#/, "");
+    const targetId =
+      hash ||
+      (focus === "rewards"
+        ? "rewards"
+        : focus === "stake"
+          ? "stake-manage"
+          : "");
+    if (!targetId) return;
+
+    return scrollToTargetWhenReady(targetId);
+  }, []);
 
   // Dynamic stats or loading placeholder
   const totalSupply = stats
@@ -184,6 +213,11 @@ function StyfiPageShell() {
       />
 
       <main className="container mx-auto px-4 md:px-6 pt-8 space-y-6 pb-24">
+        <CrossAppNudge
+          nudge={nudge}
+          onDismiss={dismiss}
+        />
+
         <AccountSummary
           isNewUser={isNewUser}
           selectedAsset={activeAsset}
@@ -196,7 +230,7 @@ function StyfiPageShell() {
           connectBody={copy.page.connectBanner.body}
         />
 
-        <div ref={cockpitRef} className="scroll-mt-8">
+        <div id="stake-manage" ref={cockpitRef} className="scroll-mt-8">
           <StyfiCockpit
             selectedAsset={activeAsset}
             onSelectAsset={handleSelectAsset}

--- a/app/styfi/components/MockControls.tsx
+++ b/app/styfi/components/MockControls.tsx
@@ -5,14 +5,17 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useAccount } from "wagmi";
 import { Button } from "@/components/ui/Button";
 import { styfiKeys } from "@/lib/hooks/useStyfi";
+import { veyfiKeys } from "@/lib/hooks/useVeyfi";
 import { useProtocol } from "@/state/protocol";
 import { toast } from "@/components/ui/Toast";
 import { DebugControls } from "@/components/DebugControls";
+import { LlyfiTokenId } from "@/lib/clients/veyfi";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
 
 export function MockControls() {
   const queryClient = useQueryClient();
   const { address } = useAccount();
-  const { styfi } = useProtocol();
+  const { styfi, veyfi } = useProtocol();
 
   const handleInjectBalance = useCallback(
     async (mode: "stYFI" | "stYFIx") => {
@@ -22,9 +25,14 @@ export function MockControls() {
       if (address && styfi.debugSetBalance) {
         // Connected: Apply immediately
         styfi.debugSetBalance(address, mode, amount);
-        await queryClient.invalidateQueries({
-          queryKey: styfiKeys.account(address),
-        });
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: styfiKeys.account(address),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ["cross-app", "nudge"],
+          }),
+        ]);
         toast.success(`Added 100 ${mode} to ${address.slice(0, 6)}...`);
       } else if (styfi.debugSetPendingBalance) {
         // Disconnected: Queue for next connection
@@ -34,6 +42,66 @@ export function MockControls() {
     },
     [address, styfi, queryClient]
   );
+
+  const handleInjectVeYfi = useCallback(async () => {
+    const amount = 10n * 10n ** 18n;
+    if (!veyfi.debugSetPendingVeYfi) return;
+
+    veyfi.debugSetPendingVeYfi(amount);
+    if (address) {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: veyfiKeys.account(address),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["cross-app", "nudge"],
+        }),
+      ]);
+      toast.success("Added 10 legacy veYFI");
+      return;
+    }
+
+    toast.success("Pending: 10 legacy veYFI will be added upon connection");
+  }, [veyfi, address, queryClient]);
+
+  const handleInjectLlyfi = useCallback(
+    async (symbol: LlyfiTokenId, amount: bigint) => {
+      if (address && veyfi.debugSetLlyfiBalance) {
+        veyfi.debugSetLlyfiBalance(address, symbol, amount);
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: veyfiKeys.account(address),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ["cross-app", "nudge"],
+          }),
+        ]);
+        toast.success(
+          `Added ${amount / 10n ** 18n} ${getLlyfiDisplaySymbol(symbol)}`
+        );
+      } else {
+        toast.error("Connect wallet first");
+      }
+    },
+    [veyfi, address, queryClient]
+  );
+
+  const handleInjectYfi = useCallback(async () => {
+    const amount = 10n * 10n ** 18n;
+    if (address && styfi.debugMintYfi) {
+      styfi.debugMintYfi(address, amount);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: ["protocol", "identity", address],
+        }),
+        queryClient.invalidateQueries({ queryKey: styfiKeys.account(address) }),
+        queryClient.invalidateQueries({ queryKey: ["cross-app", "nudge"] }),
+      ]);
+      toast.success("Added 10 YFI");
+    } else {
+      toast.error("Connect wallet first");
+    }
+  }, [styfi, address, queryClient]);
 
   return (
     <DebugControls>
@@ -51,6 +119,37 @@ export function MockControls() {
           onClick={() => handleInjectBalance("stYFIx")}
         >
           Add stYFIx
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 border-t border-neutral-100 pt-2 mb-2">
+        <Button size="sm" variant="secondary" onClick={handleInjectVeYfi}>
+          +10 Legacy veYFI
+        </Button>
+        <Button size="sm" variant="secondary" onClick={handleInjectYfi}>
+          +10 YFI
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => handleInjectLlyfi("sdYFI", 10n * 10n ** 18n)}
+        >
+          +10 sdYFI
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => handleInjectLlyfi("coveYFI", 10n * 10n ** 18n)}
+        >
+          +10 coveYFI
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          className="col-span-2"
+          onClick={() => handleInjectLlyfi("upYFI", 10000n * 10n ** 18n)}
+        >
+          +10,000 {getLlyfiDisplaySymbol("upYFI")}
         </Button>
       </div>
     </DebugControls>

--- a/app/styfi/components/StyfiCockpit.tsx
+++ b/app/styfi/components/StyfiCockpit.tsx
@@ -37,7 +37,9 @@ export function StyfiCockpit({
           selectedAsset={selectedAsset}
           onSelectAsset={onSelectAsset}
         />
-        <RewardsCard />
+        <div id="rewards" className="scroll-mt-8">
+          <RewardsCard />
+        </div>
       </div>
 
       {usesMockBackend && <MockModeBanner />}

--- a/app/styfi/page.tsx
+++ b/app/styfi/page.tsx
@@ -81,6 +81,8 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 // app/styfi/page.tsx
-export default function StyfiPage() {
-  return <StyfiPageClient />;
+export default async function StyfiPage() {
+  const headerList = await headers();
+  const hostname = headerList.get("host");
+  return <StyfiPageClient hostname={hostname} />;
 }

--- a/app/veyfi/VeyfiPageClient.tsx
+++ b/app/veyfi/VeyfiPageClient.tsx
@@ -1,9 +1,13 @@
 "use client";
 
+import { useEffect } from "react";
 import { VeyfiStatsBar } from "./components/VeyfiStatsBar";
 import { VeyfiCockpit } from "./components/VeyfiCockpit";
 import { useProtocol } from "@/state/protocol";
 import { MockControls } from "./components/MockControls";
+import { CrossAppNudge } from "@/components/domain/CrossAppNudge";
+import { useCrossChainNudge } from "@/lib/hooks/useCrossChainNudge";
+import { scrollToTargetWhenReady } from "@/lib/scrollToTarget";
 
 type VeyfiPageClientProps = {
   hostname?: string | null;
@@ -11,12 +15,35 @@ type VeyfiPageClientProps = {
 
 export function VeyfiPageClient({ hostname }: VeyfiPageClientProps) {
   const { usesMockBackend } = useProtocol();
+  const { nudge, dismiss } = useCrossChainNudge({
+    currentApp: "veyfi",
+    hostname,
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const search = new URLSearchParams(window.location.search);
+    const action = search.get("action");
+    const focus = search.get("focus");
+    const hash = window.location.hash.replace(/^#/, "");
+    const targetId =
+      hash ||
+      (action === "migration"
+        ? "migration-card"
+        : focus === "stake" || focus === "manage"
+          ? "llyfi-ledger"
+          : "");
+    if (!targetId) return;
+
+    return scrollToTargetWhenReady(targetId);
+  }, []);
 
   return (
     <div className="space-y-0">
       <VeyfiStatsBar />
 
       <main className="container mx-auto px-4 md:px-6 pt-8 space-y-8 pb-24">
+        <CrossAppNudge nudge={nudge} onDismiss={dismiss} />
         <VeyfiCockpit hostname={hostname} />
       </main>
 

--- a/app/veyfi/components/LlyfiTokenTable.tsx
+++ b/app/veyfi/components/LlyfiTokenTable.tsx
@@ -20,7 +20,7 @@ export function LlyfiTokenTable() {
 
   if (!isS3Ready || tokens.length === 0) {
     return (
-      <div className="space-y-4">
+      <div id="llyfi-ledger" className="space-y-4">
         <h3 className="text-xl font-bold text-neutral-900 px-1">
           {copy.manage.title}
         </h3>
@@ -71,7 +71,7 @@ export function LlyfiTokenTable() {
   }
 
   return (
-    <div className="space-y-4">
+    <div id="llyfi-ledger" className="space-y-4">
       <h3 className="text-xl font-bold text-neutral-900 px-1">
         {copy.manage.title}
       </h3>

--- a/app/veyfi/components/MigrationCard.tsx
+++ b/app/veyfi/components/MigrationCard.tsx
@@ -107,7 +107,10 @@ export function MigrationCard() {
   if (showAction) {
     // PRE-MIGRATION STATE (Uses veYFI Balance)
     return (
-      <Card className="bg-neutral-900 text-neutral-0 border-neutral-700 overflow-hidden relative dark:bg-surface dark:text-text-primary dark:border-border">
+      <Card
+        id="migration-card"
+        className="bg-neutral-900 text-neutral-0 border-neutral-700 overflow-hidden relative dark:bg-surface dark:text-text-primary dark:border-border"
+      >
         {/* Ambient glow effect */}
         <div className="absolute top-0 right-0 w-64 h-64 bg-disco-900/20 blur-3xl rounded-full -translate-y-1/2 translate-x-1/3 pointer-events-none" />
 
@@ -156,7 +159,10 @@ export function MigrationCard() {
   if (migrated) {
     // POST-MIGRATION STATE (Refined Design)
     return (
-      <Card className="border-disco-200 bg-disco-50/50 dark:bg-surface dark:border-disco-700/60">
+      <Card
+        id="migration-card"
+        className="border-disco-200 bg-disco-50/50 dark:bg-surface dark:border-disco-700/60"
+      >
         <div className="flex flex-col md:flex-row items-stretch gap-8">
           {/* Left: Info */}
           <div className="flex-1 space-y-4">

--- a/app/veyfi/components/MockControls.tsx
+++ b/app/veyfi/components/MockControls.tsx
@@ -23,9 +23,12 @@ export function MockControls() {
     if (veyfi.debugSetPendingVeYfi) {
       veyfi.debugSetPendingVeYfi(amount);
       if (address) {
-        await queryClient.invalidateQueries({
-          queryKey: veyfiKeys.account(address),
-        });
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: veyfiKeys.account(address),
+          }),
+          queryClient.invalidateQueries({ queryKey: ["cross-app", "nudge"] }),
+        ]);
         toast.success("Added 10 legacy veYFI");
       } else {
         toast.success("Pending: 10 legacy veYFI will be added upon connection");
@@ -37,9 +40,12 @@ export function MockControls() {
     async (symbol: LlyfiTokenId, amount: bigint) => {
       if (address && veyfi.debugSetLlyfiBalance) {
         veyfi.debugSetLlyfiBalance(address, symbol, amount);
-        await queryClient.invalidateQueries({
-          queryKey: veyfiKeys.account(address),
-        });
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: veyfiKeys.account(address),
+          }),
+          queryClient.invalidateQueries({ queryKey: ["cross-app", "nudge"] }),
+        ]);
         toast.success(
           `Added ${amount / 10n ** 18n} ${getLlyfiDisplaySymbol(symbol)}`
         );
@@ -59,12 +65,33 @@ export function MockControls() {
           queryKey: ["protocol", "identity", address],
         }),
         queryClient.invalidateQueries({ queryKey: styfiKeys.account(address) }),
+        queryClient.invalidateQueries({ queryKey: ["cross-app", "nudge"] }),
       ]);
       toast.success("Added 10 YFI");
     } else {
       toast.error("Connect wallet first");
     }
   }, [styfi, address, queryClient]);
+
+  const handleInjectStyfiBalance = useCallback(
+    async (mode: "stYFI" | "stYFIx") => {
+      const amount = 100n * 10n ** 18n;
+      if (address && styfi.debugSetBalance) {
+        styfi.debugSetBalance(address, mode, amount);
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: styfiKeys.account(address),
+          }),
+          queryClient.invalidateQueries({ queryKey: ["cross-app", "nudge"] }),
+        ]);
+        toast.success(`Added 100 ${mode}`);
+      } else if (styfi.debugSetPendingBalance) {
+        styfi.debugSetPendingBalance(mode, amount);
+        toast.success(`Pending: 100 ${mode} will be added upon connection`);
+      }
+    },
+    [address, styfi, queryClient]
+  );
 
   return (
     <DebugControls>
@@ -74,6 +101,23 @@ export function MockControls() {
         </Button>
         <Button size="sm" variant="secondary" onClick={handleInjectYfi}>
           +10 YFI
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 border-t border-neutral-100 pt-2 mb-2">
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => handleInjectStyfiBalance("stYFI")}
+        >
+          +100 stYFI
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => handleInjectStyfiBalance("stYFIx")}
+        >
+          +100 stYFIx
         </Button>
       </div>
 

--- a/components/domain/CrossAppNudge.tsx
+++ b/components/domain/CrossAppNudge.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import Link from "next/link";
+import { Banner } from "@/components/ui/Banner";
+import { Button } from "@/components/ui/Button";
+import { IconClose } from "@/components/icons/IconClose";
+import { IconLinkOut } from "@/components/icons/IconLinkOut";
+import { IconStar } from "@/components/icons/IconStar";
+import { cn } from "@/lib/cn";
+import type { CrossAppNudge as CrossAppNudgeData } from "@/lib/hooks/useCrossChainNudge";
+
+type CrossAppNudgeProps = {
+  nudge: CrossAppNudgeData | null;
+  onDismiss: (nudgeId: string) => void;
+  className?: string;
+};
+
+export function CrossAppNudge({
+  nudge,
+  onDismiss,
+  className,
+}: CrossAppNudgeProps) {
+  const isOpen = !!nudge;
+
+  return (
+    <div
+      className={cn(
+        "grid overflow-hidden transition-[grid-template-rows,opacity] duration-300",
+        isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0",
+        className
+      )}
+    >
+      <div className="overflow-hidden">
+        {nudge && (
+          <Banner
+            variant="brand"
+            className="relative animate-in slide-in-from-top-2 duration-500 pr-12"
+          >
+            <button
+              type="button"
+              aria-label="Dismiss nudge"
+              onClick={() => onDismiss(nudge.id)}
+              className="absolute top-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-md text-sky-700 hover:bg-sky-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-600"
+            >
+              <IconClose className="h-4 w-4" />
+            </button>
+
+            <div className="flex items-start gap-3">
+              <IconStar className="h-5 w-5 shrink-0 text-sky-600 mt-0.5" />
+              <div className="space-y-2">
+                <div className="space-y-0.5">
+                  <p className="font-bold">{nudge.title}</p>
+                  <p>{nudge.body}</p>
+                </div>
+
+                <Link
+                  href={nudge.href}
+                  className="inline-block"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="border-sky-300 bg-white/80 hover:bg-white"
+                  >
+                    <span className="inline-flex items-center gap-1.5">
+                      {nudge.ctaLabel}
+                      <IconLinkOut className="h-3.5 w-3.5" aria-hidden />
+                    </span>
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </Banner>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/Banner.tsx
+++ b/components/ui/Banner.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/lib/cn";
 import React from "react";
 
 interface BannerProps extends React.HTMLAttributes<HTMLDivElement> {
-  variant?: "warning" | "error" | "info";
+  variant?: "warning" | "error" | "info" | "brand";
   title?: string;
 }
 
@@ -17,6 +17,7 @@ export function Banner({
     warning: "bg-amber-100 text-amber-900 border-amber-200",
     error: "bg-red-100 text-red-900 border-red-200",
     info: "bg-blue-50 text-blue-900 border-blue-200",
+    brand: "bg-sky-50 text-sky-950 border-sky-200",
   };
 
   return (

--- a/docs/apps/styfi/ui-spec.md
+++ b/docs/apps/styfi/ui-spec.md
@@ -2,7 +2,7 @@
 
 **Status:** Final
 **Applies to:** `styfi.yearn.fi` (and `/styfi` route)
-**Last updated:** 2026-01-20
+**Last updated:** 2026-02-11
 
 ---
 
@@ -151,3 +151,29 @@ Always visible and owns all write interactions.
 | :----------- | :--------------- | :-------------------------------- |
 | New User     | 0                | AccountSummary → ModeComparison   |
 | Returning    | > 0              | AccountSummary → Positions List   |
+
+---
+
+## 10. Cross-App Nudge
+
+- **Goal:** Contextual guidance to `/veyfi` without interrupting staking flows.
+- **Trigger policy:** Show at most one nudge, and only for high-intent actions:
+  - legacy veYFI migration available
+  - unstaked liquid locker tokens in wallet
+  - intentionally **does not** show passive/manage-only nudges to avoid fatigue
+- **Connection gating:** Nudge evaluation requires an actual connected wallet (`wagmi` connected), not only mock fallback identity.
+- **Data path:** stYFI uses a lightweight veYFI nudge read (`getNudgeState`) instead of full veYFI account hydration.
+  - Includes only: legacy migration signal + per-token liquid locker balances.
+  - Excludes: allowances, cooldown streams, redemption caps, and cockpit-level data.
+- **Copy source:** All nudge copy is defined in shared message config (`app/_shared/messages.ts`), not hardcoded in hook logic.
+- **Amount formatting:** token values use standard token formatting with 4 decimal precision; liquid locker copy lists per-token symbols and amounts.
+- **Visual treatment:** Brand-tinted banner with row-collapse animation (`grid-template-rows`) and top-right dismiss action.
+- **Dismiss behavior:** `X` only; dismissal snoozes for 7 days per wallet and nudge ID.
+- **CTA behavior:**
+  - Label: "Visit veYFI website"
+  - Opens in a new tab with external-link icon
+  - Hostname-aware routing via governance link resolver:
+    - `localhost` / `app.dao-ops.com` -> path-scoped `/veyfi`
+    - `*.yearn.fi` -> canonical `https://veyfi.yearn.fi`
+- **Deep-link behavior:** CTA routes include `source=nudge` + action/focus params.
+- **Scroll reliability:** Target scrolling uses DOM-observer readiness checks (`MutationObserver`) rather than fixed timeout delays.

--- a/docs/apps/veyfi/ui-spec.md
+++ b/docs/apps/veyfi/ui-spec.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented (Phase 6 Complete)
 **Applies to:** `veyfi.yearn.fi` (and `/veyfi` route)
-**Last updated:** 2026-01-08
+**Last updated:** 2026-02-11
 
 ---
 
@@ -138,3 +138,28 @@ The frontend requires a new `getGlobalStats()` method from the VeyfiClient to po
 - **Colors:**
   - **veYFI/LLYFI:** "Disco Salmon" (#CC3767).
   - **Warnings/Caps:** Amber/Red if caps are near full.
+
+---
+
+## 7. Cross-App Nudge
+
+- **Goal:** Contextual guidance to `/styfi` only when an immediate stake action is available.
+- **Trigger policy:** Show at most one nudge for high-intent action:
+  - unstaked YFI in wallet
+  - intentionally **does not** show claim/manage-only nudges to reduce banner fatigue
+- **Connection gating:** Nudge evaluation requires an actual connected wallet (`wagmi` connected), not only mock fallback identity.
+- **Data path:** veYFI uses a lightweight stYFI nudge read (`getNudgeState`) instead of full stYFI page-state hydration.
+  - Includes only: YFI wallet balance + minimal stake-state signals.
+  - Excludes: allowances, cockpit tab state, and full rewards card derivations.
+- **Copy source:** All nudge copy is defined in shared message config (`app/_shared/messages.ts`), not hardcoded in hook logic.
+- **Amount formatting:** token values use standard token formatting with 4 decimal precision.
+- **Visual treatment:** Brand-tinted banner with row-collapse animation (no fixed mobile `min-height`) and top-right dismiss action.
+- **Dismiss behavior:** `X` only; dismissal snoozes for 7 days per wallet and nudge ID.
+- **CTA behavior:**
+  - Label: "Visit stYFI website"
+  - Opens in a new tab with external-link icon
+  - Hostname-aware routing via governance link resolver:
+    - `localhost` / `app.dao-ops.com` -> path-scoped `/styfi`
+    - `*.yearn.fi` -> canonical `https://styfi.yearn.fi`
+- **Deep-link behavior:** CTA routes include `source=nudge` + focus/action params.
+- **Scroll reliability:** Deep-link scroll waits for DOM target readiness via `MutationObserver` instead of fixed timers.

--- a/docs/shared/mock-toggles.md
+++ b/docs/shared/mock-toggles.md
@@ -6,6 +6,7 @@
 - **Default:** Disabled in repo; enable for local UI-only testing.
 - **Effect:** Uses `MockStyfiClient` and `MockVeyfiClient` instead of on-chain calls.
 - **Clock behavior in mock mode:** Epoch and cooldown UI timing uses the local mock clock (`nowSeconds`) instead of chain/S3 canonical clock sources.
+- **Manual UAT tip:** For wallet-connect UX testing in mock mode, set `NEXT_PUBLIC_E2E=false`. If `NEXT_PUBLIC_E2E=true`, the app uses a fixed mock connector address and behaves as connected.
 
 ## Clock Source by Mode
 
@@ -58,9 +59,11 @@ When running with mocks enabled, a **"🛠️ Debug"** button appears at the bot
 
 2.  **Balance Injection:**
 
-    - `Add stYFI`: Injects 100 stYFI into the connected address.
-    - `Add stYFIx`: Injects 100 stYFIx into the connected address.
-    - _Note:_ If wallet is disconnected, these queue a balance injection for the next address that connects. Use this to test the default asset selection logic.
+    - Cross-app controls are available on both `/styfi` and `/veyfi` debug panels.
+    - stYFI actions: `Add stYFI`, `Add stYFIx`.
+    - veYFI actions: `+10 Legacy veYFI`, `+10 sdYFI`, `+10 coveYFI`, `+10,000 supYFI`.
+    - wallet action: `+10 YFI`.
+    - _Note:_ stYFI balance injections can queue for the next wallet connection; other token injections require a connected wallet.
 
 3.  **Local State Tools:**
     - `Reset App`: Full wipe of `localStorage`, `sessionStorage` (chain state), and query cache. Simulates a completely fresh install.

--- a/docs/shared/testing.md
+++ b/docs/shared/testing.md
@@ -155,6 +155,7 @@ Playwright can also be run directly:
 - `NEXT_PUBLIC_USE_MOCKS=true` ensures the app uses mock clients.
 - `NEXT_PUBLIC_E2E=true` also forces mock clients for safety.
 - `NEXT_PUBLIC_MOCK_TIME_OFFSET_SECONDS` can offset the clock in dev.
+- For manual UI QA of disconnected states while mocks are enabled, use `NEXT_PUBLIC_USE_MOCKS=true` with `NEXT_PUBLIC_E2E=false` (otherwise the mock connector is auto-connected).
 
 ## Common Failure Modes
 

--- a/lib/clients/styfi/client.ts
+++ b/lib/clients/styfi/client.ts
@@ -1,12 +1,18 @@
 // lib/clients/styfi/client.ts
 import type { Address } from "viem";
 import type { PreparedTransaction } from "@/lib/tx/types";
-import type { EpochInfo, StyfiAccountState, StyfiGlobalStats } from "./types";
+import type {
+  EpochInfo,
+  StyfiAccountState,
+  StyfiGlobalStats,
+  StyfiNudgeState,
+} from "./types";
 
 export type StyfiStakeMode = "stYFI" | "stYFIx";
 
 export interface StyfiClient {
   getAccountState(address: Address): Promise<StyfiAccountState>;
+  getNudgeState(address: Address): Promise<StyfiNudgeState>;
   getEpochInfo(): Promise<EpochInfo>;
   getStats(): Promise<StyfiGlobalStats>;
   /**

--- a/lib/clients/styfi/mock.ts
+++ b/lib/clients/styfi/mock.ts
@@ -3,7 +3,12 @@
 
 import type { Address } from "viem";
 import type { PreparedTransaction, TransactionHash } from "@/lib/tx/types";
-import type { StyfiAccountState, StyfiGlobalStats, EpochInfo } from "./types";
+import type {
+  StyfiAccountState,
+  StyfiGlobalStats,
+  EpochInfo,
+  StyfiNudgeState,
+} from "./types";
 import type { StyfiClient, StyfiStakeMode } from "./client";
 import { GLOBAL_WORLD_STATE } from "@/lib/mocks/world-state";
 import {
@@ -159,6 +164,21 @@ export class MockStyfiClient implements StyfiClient {
     );
 
     return cloneState(state);
+  }
+
+  async getNudgeState(address: Address): Promise<StyfiNudgeState> {
+    const state = await this.getAccountState(address);
+    return {
+      yfiBalance: state.yfiBalance,
+      styfiActive: state.styfiActive,
+      styfiInCooldown: state.styfiInCooldown,
+      styfiWithdrawable: state.styfiWithdrawable,
+      styfiXActive: state.styfiX.assetsActive,
+      styfiXInCooldown: state.styfiX.assetsInCooldown,
+      styfiXWithdrawable: state.styfiX.assetsWithdrawable,
+      claimableRewards:
+        state.claimableGenericRewards + state.claimableBoostedRewards,
+    };
   }
 
   async getEpochInfo(): Promise<EpochInfo> {

--- a/lib/clients/styfi/onchain.ts
+++ b/lib/clients/styfi/onchain.ts
@@ -3,7 +3,12 @@ import { type Address, type PublicClient, erc20Abi } from "viem";
 import { getAccount, writeContract } from "wagmi/actions";
 import { wagmiConfig } from "@/web3/wagmi";
 import type { PreparedTransaction } from "@/lib/tx/types";
-import type { StyfiAccountState, StyfiGlobalStats, EpochInfo } from "./types";
+import type {
+  StyfiAccountState,
+  StyfiGlobalStats,
+  EpochInfo,
+  StyfiNudgeState,
+} from "./types";
 import type { StyfiClient, StyfiStakeMode } from "./client";
 import { getEpochInfo as getEpochInfoFromGenesis } from "@/lib/format";
 import type { GlobalData } from "@/lib/schemas/global";
@@ -286,6 +291,91 @@ export class OnchainStyfiClient implements StyfiClient {
     } catch {
       console.warn("Failed to fetch stYFI account state; using fallback data.");
       return this.buildFallbackAccountState(address, nowSeconds());
+    }
+  }
+
+  async getNudgeState(address: Address): Promise<StyfiNudgeState> {
+    if (!this.publicClient) {
+      return {
+        yfiBalance: 0n,
+        styfiActive: 0n,
+        styfiInCooldown: 0n,
+        styfiWithdrawable: 0n,
+        styfiXActive: 0n,
+        styfiXInCooldown: 0n,
+        styfiXWithdrawable: 0n,
+        claimableRewards: 0n,
+      };
+    }
+
+    try {
+      const commonStyfi = {
+        abi: StakedYfiAbi,
+        address: STYFI_ADDRESS,
+      } as const;
+      const commonStyfix = {
+        abi: DelegatedStakedYfiAbi,
+        address: STYFIX_ADDRESS,
+      } as const;
+      const commonYfi = { abi: erc20Abi, address: YFI_ADDRESS } as const;
+
+      const [
+        yfiBalance,
+        styfiActive,
+        styfiStream,
+        styfiMaxWithdraw,
+        styfiXActive,
+        styfiXStream,
+        styfiXMaxWithdraw,
+      ] = await this.publicClient.multicall({
+        contracts: [
+          { ...commonYfi, functionName: "balanceOf", args: [address] },
+          { ...commonStyfi, functionName: "balanceOf", args: [address] },
+          { ...commonStyfi, functionName: "streams", args: [address] },
+          { ...commonStyfi, functionName: "maxWithdraw", args: [address] },
+          { ...commonStyfix, functionName: "balanceOf", args: [address] },
+          { ...commonStyfix, functionName: "streams", args: [address] },
+          { ...commonStyfix, functionName: "maxWithdraw", args: [address] },
+        ],
+        allowFailure: false,
+      });
+
+      let claimableRewards = 0n;
+      try {
+        const { result } = await this.publicClient.simulateContract({
+          address: REWARD_CLAIMER_ADDRESS,
+          abi: RewardClaimerAbi,
+          functionName: "claim",
+          args: [address],
+          account: address,
+        });
+        claimableRewards = result;
+      } catch {
+        claimableRewards = 0n;
+      }
+
+      return {
+        yfiBalance,
+        styfiActive,
+        styfiInCooldown: styfiStream[1] - styfiStream[2],
+        styfiWithdrawable: styfiMaxWithdraw,
+        styfiXActive,
+        styfiXInCooldown: styfiXStream[1] - styfiXStream[2],
+        styfiXWithdrawable: styfiXMaxWithdraw,
+        claimableRewards,
+      };
+    } catch {
+      console.warn("Failed to fetch stYFI nudge state; using fallback data.");
+      return {
+        yfiBalance: 0n,
+        styfiActive: 0n,
+        styfiInCooldown: 0n,
+        styfiWithdrawable: 0n,
+        styfiXActive: 0n,
+        styfiXInCooldown: 0n,
+        styfiXWithdrawable: 0n,
+        claimableRewards: 0n,
+      };
     }
   }
 

--- a/lib/clients/styfi/types.ts
+++ b/lib/clients/styfi/types.ts
@@ -13,6 +13,24 @@ export type StyfiGlobalStats = {
   totalStaked: bigint; // Total YFI staked (stYFI + stYFIx) across all users
 };
 
+export type StyfiNudgeState = {
+  // Wallet
+  yfiBalance: bigint;
+
+  // stYFI
+  styfiActive: bigint;
+  styfiInCooldown: bigint;
+  styfiWithdrawable: bigint;
+
+  // stYFIx
+  styfiXActive: bigint;
+  styfiXInCooldown: bigint;
+  styfiXWithdrawable: bigint;
+
+  // Rewards
+  claimableRewards: bigint;
+};
+
 export type StyfiAllowances = {
   yfiToStyfi: bigint;
   yfiToStyfiX: bigint;

--- a/lib/clients/veyfi/client.ts
+++ b/lib/clients/veyfi/client.ts
@@ -3,10 +3,12 @@ import type {
   VeyfiAccountState,
   LlyfiTokenId,
   VeyfiGlobalStats,
+  VeyfiNudgeState,
 } from "./types";
 
 export interface VeyfiClient {
   getAccountState(address: `0x${string}`): Promise<VeyfiAccountState>;
+  getNudgeState(address: `0x${string}`): Promise<VeyfiNudgeState>;
   getGlobalStats(): Promise<VeyfiGlobalStats>;
   /**
    * Optional: force an on-chain stats fetch, bypassing S3.

--- a/lib/clients/veyfi/mock.ts
+++ b/lib/clients/veyfi/mock.ts
@@ -7,6 +7,7 @@ import type {
   VeyfiAccountState,
   LlyfiTokenId,
   VeyfiGlobalStats,
+  VeyfiNudgeState,
 } from "./types";
 import type { VeyfiClient } from "./client";
 import { GLOBAL_WORLD_STATE } from "@/lib/mocks/world-state";
@@ -218,6 +219,21 @@ export class MockVeyfiClient implements VeyfiClient {
       GLOBAL_REDEMPTION.tokens.coveYFI.inventory;
 
     return state;
+  }
+
+  async getNudgeState(address: Address): Promise<VeyfiNudgeState> {
+    const state = await this.getAccountState(address);
+    return {
+      legacyBalance: state.veYfi?.legacyBalance ?? 0n,
+      migrationEligible: state.veYfi?.migrationEligible ?? false,
+      migrated: state.veYfi?.migrated ?? false,
+      llyfiTokens: state.llyfiTokens.map((token) => ({
+        symbol: token.symbol,
+        walletBalance: token.walletBalance,
+        stakedBalance:
+          token.stakedBalance + token.cooldownBalance + token.withdrawable,
+      })),
+    };
   }
 
   async getGlobalStats(): Promise<VeyfiGlobalStats> {

--- a/lib/clients/veyfi/onchain.ts
+++ b/lib/clients/veyfi/onchain.ts
@@ -8,6 +8,7 @@ import type {
   LlyfiTokenId,
   LlyfiTokenState,
   LlyfiGlobalInfo,
+  VeyfiNudgeState,
 } from "./types";
 import type { VeyfiClient } from "./client";
 import type { GlobalData } from "@/lib/schemas/global";
@@ -352,6 +353,110 @@ export class OnchainVeyfiClient implements VeyfiClient {
         veYfi: null,
         llyfiTokens: [],
         inventory: { availableYfi: 0n, feeBps: 0 },
+      };
+    }
+  }
+
+  async getNudgeState(address: Address): Promise<VeyfiNudgeState> {
+    if (!this.publicClient) {
+      return {
+        legacyBalance: 0n,
+        migrationEligible: false,
+        migrated: false,
+        llyfiTokens: [],
+      };
+    }
+
+    try {
+      const [legacyLockResult, snapshotCheckResult, lockInfo, lastClaimed] =
+        await this.publicClient.multicall({
+          contracts: [
+            {
+              address: VEYFI_ADDRESS,
+              abi: LegacyVeYfiAbi,
+              functionName: "locked",
+              args: [address],
+            },
+            {
+              address: VEYFI_REWARD_DISTRIBUTOR_ADDRESS,
+              abi: VotingEscrowRewardDistributorAbi,
+              functionName: "check_lock",
+              args: [address],
+            },
+            {
+              address: VEYFI_REWARD_DISTRIBUTOR_ADDRESS,
+              abi: VotingEscrowRewardDistributorAbi,
+              functionName: "locks",
+              args: [address],
+            },
+            {
+              address: VEYFI_REWARD_DISTRIBUTOR_ADDRESS,
+              abi: VotingEscrowRewardDistributorAbi,
+              functionName: "last_claimed",
+              args: [address],
+            },
+          ],
+          allowFailure: false,
+        });
+
+      const lockerCalls = LIQUID_LOCKERS.flatMap((locker) => [
+        {
+          address: locker.token,
+          abi: erc20Abi,
+          functionName: "balanceOf",
+          args: [address],
+        },
+        {
+          address: locker.depositor,
+          abi: LiquidLockerDepositorAbi,
+          functionName: "balanceOf",
+          args: [address],
+        },
+      ]);
+
+      const lockerResults = await this.publicClient.multicall({
+        contracts: lockerCalls,
+        allowFailure: false,
+      });
+
+      const legacyBalance = BigInt(legacyLockResult[0] as bigint);
+      const snapshotAmount = (lockInfo as LockInfo).amount;
+      const snapshotValidAmount = (snapshotCheckResult as [bigint, bigint])[0];
+      const migrated = (lastClaimed as bigint) > 0n;
+      const migrationEligible =
+        !migrated && snapshotAmount > 0n && snapshotValidAmount > 0n;
+
+      const llyfiTokens: Array<{
+        symbol: LlyfiTokenId;
+        walletBalance: bigint;
+        stakedBalance: bigint;
+      }> = [];
+
+      for (let i = 0; i < LIQUID_LOCKERS.length; i++) {
+        const config = LIQUID_LOCKERS[i];
+        const base = i * 2;
+        const walletBalance = lockerResults[base] as bigint;
+        const stakedBalanceShares = lockerResults[base + 1] as bigint;
+        llyfiTokens.push({
+          symbol: config.symbol,
+          walletBalance,
+          stakedBalance: stakedBalanceShares * config.scale,
+        });
+      }
+
+      return {
+        legacyBalance,
+        migrationEligible,
+        migrated,
+        llyfiTokens,
+      };
+    } catch {
+      console.warn("Failed to fetch veYFI nudge state; using fallback data.");
+      return {
+        legacyBalance: 0n,
+        migrationEligible: false,
+        migrated: false,
+        llyfiTokens: [],
       };
     }
   }

--- a/lib/clients/veyfi/types.ts
+++ b/lib/clients/veyfi/types.ts
@@ -58,6 +58,17 @@ export type VeyfiInventory = {
   feeBps: number;
 };
 
+export type VeyfiNudgeState = {
+  legacyBalance: bigint;
+  migrationEligible: boolean;
+  migrated: boolean;
+  llyfiTokens: Array<{
+    symbol: LlyfiTokenId;
+    walletBalance: bigint;
+    stakedBalance: bigint;
+  }>;
+};
+
 export type VeyfiAccountState = {
   address: Address;
   veYfi: {

--- a/lib/hooks/useCrossChainNudge.ts
+++ b/lib/hooks/useCrossChainNudge.ts
@@ -1,0 +1,232 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useSearchParams } from "next/navigation";
+import { useAccount } from "wagmi";
+import { resolveGovernanceAppHref } from "@/lib/governance-links";
+import { formatTokenAmount } from "@/lib/format";
+import { getLlyfiDisplaySymbol } from "@/lib/clients/veyfi/display";
+import { crossAppNudgeCopy as copy } from "@/app/_shared/messages";
+import { useIdentity } from "@/state/identity";
+import { useProtocol } from "@/state/protocol";
+import type { StyfiNudgeState } from "@/lib/clients/styfi";
+import type { VeyfiNudgeState } from "@/lib/clients/veyfi";
+
+type NudgeApp = "styfi" | "veyfi";
+
+export type CrossAppNudge = {
+  id: string;
+  title: string;
+  body: string;
+  ctaLabel: string;
+  href: string;
+  targetApp: NudgeApp;
+  priority: number;
+};
+
+type UseCrossChainNudgeOptions = {
+  currentApp: NudgeApp;
+  hostname?: string | null;
+};
+
+const DUST_THRESHOLD = 10n ** 15n; // 0.001 token units (18 decimals)
+const DISMISS_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function formatTokenForCopy(amount: bigint) {
+  return formatTokenAmount(amount, 18, 4);
+}
+
+function formatTokenList(
+  tokens: Array<{ symbol: string; amount: bigint }>,
+  maxItems = 2
+) {
+  const entries = tokens
+    .filter((token) => token.amount > DUST_THRESHOLD)
+    .map((token) => `${formatTokenForCopy(token.amount)} ${token.symbol}`);
+
+  if (entries.length === 0) return "";
+  if (entries.length <= maxItems) return entries.join(", ");
+  return `${entries.slice(0, maxItems).join(", ")}, +${entries.length - maxItems} more`;
+}
+
+function toHashFragment(hash?: string) {
+  if (!hash) return "";
+  return hash.startsWith("#") ? hash : `#${hash}`;
+}
+
+function buildNudgeHref(
+  app: NudgeApp,
+  hostname: string | null | undefined,
+  params: Record<string, string>,
+  hash?: string
+) {
+  const baseHref = resolveGovernanceAppHref(app, hostname);
+  const query = new URLSearchParams(params).toString();
+  return `${baseHref}?${query}${toHashFragment(hash)}`;
+}
+
+function buildStyfiPageNudge(
+  state: VeyfiNudgeState,
+  hostname?: string | null
+): CrossAppNudge | null {
+  const hasLegacyMigration =
+    state.legacyBalance > DUST_THRESHOLD &&
+    state.migrationEligible &&
+    !state.migrated;
+  const hasUnstakedLlyfi = state.llyfiTokens.some(
+    (token) => token.walletBalance > DUST_THRESHOLD
+  );
+  const walletTokenSummary = formatTokenList(
+    state.llyfiTokens.map((token) => ({
+      symbol: getLlyfiDisplaySymbol(token.symbol),
+      amount: token.walletBalance,
+    }))
+  );
+  const legacyAmountLabel = formatTokenForCopy(state.legacyBalance);
+
+  if (hasLegacyMigration) {
+    return {
+      id: "nudge_veyfi_migration",
+      targetApp: "veyfi",
+      priority: 110,
+      title: copy.styfiPage.migration.title,
+      body: copy.styfiPage.migration.body(legacyAmountLabel),
+      ctaLabel: copy.shared.cta.toVeyfi,
+      href: buildNudgeHref(
+        "veyfi",
+        hostname,
+        { source: "nudge", from: "styfi", action: "migration" },
+        "migration-card"
+      ),
+    };
+  }
+
+  if (hasUnstakedLlyfi) {
+    return {
+      id: "nudge_veyfi_unstaked_llyfi",
+      targetApp: "veyfi",
+      priority: 90,
+      title: copy.styfiPage.unstakedLlyfi.title,
+      body: walletTokenSummary
+        ? copy.styfiPage.unstakedLlyfi.body(walletTokenSummary)
+        : copy.styfiPage.unstakedLlyfi.fallback,
+      ctaLabel: copy.shared.cta.toVeyfi,
+      href: buildNudgeHref("veyfi", hostname, {
+        source: "nudge",
+        from: "styfi",
+        focus: "stake",
+      }),
+    };
+  }
+
+  return null;
+}
+
+function buildVeyfiPageNudge(
+  state: StyfiNudgeState,
+  hostname?: string | null
+): CrossAppNudge | null {
+  const hasUnstakedYfi = state.yfiBalance > DUST_THRESHOLD;
+  const yfiBalanceLabel = formatTokenForCopy(state.yfiBalance);
+
+  if (hasUnstakedYfi) {
+    return {
+      id: "nudge_styfi_unstaked_yfi",
+      targetApp: "styfi",
+      priority: 90,
+      title: copy.veyfiPage.unstakedYfi.title,
+      body: copy.veyfiPage.unstakedYfi.body(yfiBalanceLabel),
+      ctaLabel: copy.shared.cta.toStyfi,
+      href: buildNudgeHref(
+        "styfi",
+        hostname,
+        { source: "nudge", from: "veyfi", focus: "stake" },
+        "stake-manage"
+      ),
+    };
+  }
+
+  return null;
+}
+
+function dismissKey(nudgeId: string, address: string) {
+  return `nudge_dismissed_${nudgeId}_${address.toLowerCase()}`;
+}
+
+export function useCrossChainNudge({
+  currentApp,
+  hostname,
+}: UseCrossChainNudgeOptions) {
+  const { address, isConnected } = useIdentity();
+  const { isConnected: isWalletConnected } = useAccount();
+  const { styfi, veyfi, publicClient, usesMockBackend } = useProtocol();
+  const searchParams = useSearchParams();
+  const [, setDismissVersion] = useState(0);
+
+  const enabled =
+    !!address &&
+    isConnected &&
+    isWalletConnected &&
+    (usesMockBackend || !!publicClient);
+  const queryKey = ["cross-app", "nudge", currentApp, address] as const;
+  const source = searchParams.get("source");
+  const from = searchParams.get("from");
+  const suppressedTarget: NudgeApp | null =
+    source === "nudge" && (from === "styfi" || from === "veyfi") ? from : null;
+
+  const { data: queryResult, isLoading } = useQuery({
+    queryKey,
+    enabled,
+    queryFn: async () => {
+      if (!address) return null;
+      if (currentApp === "styfi") {
+        const state = await veyfi.getNudgeState(address);
+        return {
+          candidate: buildStyfiPageNudge(state, hostname),
+          checkedAt: Date.now(),
+        };
+      }
+      const state = await styfi.getNudgeState(address);
+      return {
+        candidate: buildVeyfiPageNudge(state, hostname),
+        checkedAt: Date.now(),
+      };
+    },
+    refetchInterval: 30_000,
+    staleTime: 20_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const candidate = queryResult?.candidate ?? null;
+  const checkedAt = queryResult?.checkedAt ?? 0;
+  let nudge = candidate;
+  if (!address || !candidate) {
+    nudge = null;
+  } else if (suppressedTarget === candidate.targetApp) {
+    nudge = null;
+  } else if (typeof window !== "undefined") {
+    const raw = window.localStorage.getItem(dismissKey(candidate.id, address));
+    if (raw) {
+      const dismissedAt = Number(raw);
+      if (Number.isFinite(dismissedAt) && checkedAt - dismissedAt < DISMISS_TTL_MS) {
+        nudge = null;
+      }
+    }
+  }
+
+  const dismiss = useCallback(
+    (nudgeId: string) => {
+      if (!address || typeof window === "undefined") return;
+      window.localStorage.setItem(dismissKey(nudgeId, address), String(Date.now()));
+      setDismissVersion((value) => value + 1);
+    },
+    [address]
+  );
+
+  return {
+    nudge,
+    dismiss,
+    isLoading: enabled && isLoading,
+  };
+}

--- a/lib/scrollToTarget.ts
+++ b/lib/scrollToTarget.ts
@@ -1,0 +1,77 @@
+"use client";
+
+type ScrollCleanup = () => void;
+
+function scrollToElement(targetId: string) {
+  const target = document.getElementById(targetId);
+  if (!target) return null;
+
+  target.scrollIntoView({ behavior: "smooth", block: "start" });
+
+  // Perform a second pass after layout settles to avoid partial scrolls.
+  let raf2 = 0;
+  const raf1 = window.requestAnimationFrame(() => {
+    document
+      .getElementById(targetId)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+
+    raf2 = window.requestAnimationFrame(() => {
+      document
+        .getElementById(targetId)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  });
+
+  return () => {
+    if (raf1) window.cancelAnimationFrame(raf1);
+    if (raf2) window.cancelAnimationFrame(raf2);
+  };
+}
+
+export function scrollToTargetWhenReady(
+  targetId: string,
+  options?: { timeoutMs?: number }
+): ScrollCleanup {
+  if (typeof window === "undefined" || !targetId) {
+    return () => undefined;
+  }
+
+  const immediateScrollCleanup = scrollToElement(targetId);
+  if (immediateScrollCleanup) {
+    return immediateScrollCleanup;
+  }
+
+  const timeoutMs = options?.timeoutMs ?? 4000;
+  let settled = false;
+  let scrollCleanup: ScrollCleanup = () => undefined;
+
+  const observer = new MutationObserver(() => {
+    const nextCleanup = scrollToElement(targetId);
+    if (nextCleanup) {
+      scrollCleanup = nextCleanup;
+      cleanup();
+    }
+  });
+
+  if (document.body) {
+    observer.observe(document.body, {
+      subtree: true,
+      childList: true,
+      attributes: false,
+    });
+  }
+
+  const timeoutId = window.setTimeout(() => {
+    cleanup();
+  }, timeoutMs);
+
+  const cleanup = () => {
+    if (settled) return;
+    settled = true;
+    observer.disconnect();
+    window.clearTimeout(timeoutId);
+    scrollCleanup();
+  };
+
+  return cleanup;
+}

--- a/tests/components/CrossAppNudge.test.tsx
+++ b/tests/components/CrossAppNudge.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { CrossAppNudge } from "@/components/domain/CrossAppNudge";
+
+describe("CrossAppNudge", () => {
+  it("uses row-collapse animation classes instead of fixed min-height", () => {
+    const { container } = render(
+      <CrossAppNudge nudge={null} onDismiss={vi.fn()} />
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("grid-rows-[0fr]");
+    expect(root.className).not.toContain("min-h-[92px]");
+  });
+
+  it("renders nudge content and dismisses with the X action", () => {
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <CrossAppNudge
+        nudge={{
+          id: "nudge_test",
+          title: "Optimization available",
+          body: "You have unstaked LLYFI.",
+          ctaLabel: "Visit veYFI website",
+          href: "/veyfi?focus=stake",
+          targetApp: "veyfi",
+          priority: 80,
+        }}
+        onDismiss={onDismiss}
+      />
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("grid-rows-[1fr]");
+    expect(screen.getByText("Optimization available")).toBeInTheDocument();
+    const cta = screen.getByRole("button", { name: /visit veyfi website/i });
+    const ctaLink = cta.closest("a");
+    expect(ctaLink).toHaveAttribute("target", "_blank");
+    expect(ctaLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    fireEvent.click(screen.getByLabelText("Dismiss nudge"));
+    expect(onDismiss).toHaveBeenCalledWith("nudge_test");
+  });
+});

--- a/tests/unit/lib/scrollToTarget.test.tsx
+++ b/tests/unit/lib/scrollToTarget.test.tsx
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { scrollToTargetWhenReady } from "@/lib/scrollToTarget";
+
+describe("scrollToTargetWhenReady", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    if (!Element.prototype.scrollIntoView) {
+      Element.prototype.scrollIntoView = () => undefined;
+    }
+    if (!window.requestAnimationFrame) {
+      window.requestAnimationFrame = (cb: FrameRequestCallback) =>
+        window.setTimeout(() => cb(0), 16);
+    }
+    if (!window.cancelAnimationFrame) {
+      window.cancelAnimationFrame = (id: number) => window.clearTimeout(id);
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("scrolls immediately when the target exists", () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+    const element = document.createElement("div");
+    element.id = "immediate-target";
+    document.body.appendChild(element);
+
+    const cleanup = scrollToTargetWhenReady("immediate-target");
+
+    expect(scrollSpy).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("waits for a DOM mutation when the target does not exist yet", async () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+
+    const cleanup = scrollToTargetWhenReady("deferred-target", {
+      timeoutMs: 1000,
+    });
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    const element = document.createElement("div");
+    element.id = "deferred-target";
+    document.body.appendChild(element);
+
+    await Promise.resolve();
+
+    expect(scrollSpy).toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("stops observing after cleanup", async () => {
+    const scrollSpy = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+
+    const cleanup = scrollToTargetWhenReady("late-target", { timeoutMs: 1000 });
+    cleanup();
+
+    const element = document.createElement("div");
+    element.id = "late-target";
+    document.body.appendChild(element);
+
+    await Promise.resolve();
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…s, robust deep-link UX, and QA tooling

- implement lightweight nudge-state APIs for both protocol clients to avoid heavy cross-domain account hydration
- add `getNudgeState` support to stYFI and veYFI client interfaces, on-chain clients, and mock clients
- introduce cross-app nudge orchestration hook with priority logic, 0.001 dust threshold, and 7-day per-wallet dismiss TTL
- require real wallet connectivity for nudge rendering to prevent pre-connect banners in E2E/mock fallback scenarios
- centralize nudge copy in shared messages and remove hardcoded strings from nudge logic
- reduce nudge noise by removing passive/manage-only banners and keeping only high-intent action banners
- enrich nudge messaging with token amounts (4 decimal precision) and per-token liquid-locker summaries
- add brand-styled cross-app nudge component with top-right dismiss control and improved CTA spacing/layout
- update nudge CTAs to “Visit … website”, include external-link icon, open in new tab, and preserve host-aware dev/prod routing behavior
- add reliable deep-link scrolling helper using DOM readiness observation (MutationObserver) instead of fixed-time delays
- wire deep-link target IDs and scroll behavior into stYFI/veYFI pages for migration, stake-manage, rewards, and ledger anchors
- add cross-app mock controls on both stYFI and veYFI screens so banner-trigger states can be injected from either app
- invalidate cross-app nudge query state after debug injections to ensure immediate nudge refresh in QA flows
- add/extend tests for nudge rendering behavior, external CTA attributes, scroll helper behavior, and governance link routing
- update stYFI and veYFI UI specs plus shared mock/testing docs to match final trigger policy, copy ownership, CTA behavior, and UAT guidance