### PR TITLE
fix(alerts-bot): repair stYFI cooldown withdrawal account attribution

### DIFF
--- a/tests/unit/workers/alerts-bot.scanner.test.ts
+++ b/tests/unit/workers/alerts-bot.scanner.test.ts
@@ -51,6 +51,9 @@ const ERC4626_DEPOSIT_CALL_ABI = parseAbi([
 const STYFI_EXIT_CALL_ABI = parseAbi([
   "function unstake(uint256 _assets)",
 ]);
+const STYFI_WITHDRAW_CALL_ABI = parseAbi([
+  "function withdraw(uint256 _assets, address _receiver, address _owner) returns (uint256)",
+]);
 
 function hashOf(index: number): Hex {
   return `0x${index.toString(16).padStart(64, "0")}`;
@@ -760,6 +763,72 @@ describe("alerts-bot scanner fixtures", () => {
     expect(actions).toHaveLength(1);
     expect(actions[0]).toMatchObject({
       kind: "initiated_cooldown",
+      tokenSymbol: "stYFI",
+      user,
+      owner: user,
+      receiver: user,
+      caller: user,
+    });
+  });
+
+  it("reconciles stYFI withdraw actors from tx calldata when log actors are wrong but non-zero", async () => {
+    const user = userOf(34);
+    const malformedActor = userOf(340);
+    const txHash = hashOf(304);
+    const amount = 28_338_591_054_761_904n;
+    const logs: RpcLog[] = [
+      createLog({
+        address: STYFI,
+        topics: encodeEventTopics({
+          abi: ERC4626_WITHDRAW_ABI,
+          eventName: "Withdraw",
+          args: {
+            sender: malformedActor,
+            receiver: malformedActor,
+            owner: malformedActor,
+          },
+        }),
+        data: encodeAbiParameters(
+          [{ type: "uint256" }, { type: "uint256" }],
+          [amount, amount],
+        ),
+        txHash,
+        blockNumber: 64,
+        logIndex: 0,
+      }),
+    ];
+
+    const rpc = createMockRpc({
+      logs,
+      txFromByHash: {
+        [txHash.toLowerCase()]: user,
+      },
+      txToByHash: {
+        [txHash.toLowerCase()]: STYFI,
+      },
+      txInputByHash: {
+        [txHash.toLowerCase()]: encodeFunctionData({
+          abi: STYFI_WITHDRAW_CALL_ABI,
+          functionName: "withdraw",
+          args: [amount, user, user],
+        }),
+      },
+      txReceiptByHash: {
+        [txHash.toLowerCase()]: {
+          transactionHash: txHash,
+          blockHash: null,
+          blockNumber: 64,
+          status: 1,
+          logs,
+        },
+      },
+    });
+
+    const actions = await scanChunkForActions(rpc, 64, 64);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      kind: "withdrew_from_cooldown",
       tokenSymbol: "stYFI",
       user,
       owner: user,

--- a/tests/unit/workers/alerts-bot.telegram-format.test.ts
+++ b/tests/unit/workers/alerts-bot.telegram-format.test.ts
@@ -129,6 +129,35 @@ describe("alerts-bot Telegram rendering", () => {
     );
   });
 
+  it("uses owner as the primary account for cooldown-withdraw messages when user is malformed", () => {
+    const zeroAddress = "0x0000000000000000000000000000000000000000";
+    const account = "0x1111111111111111111111111111111111111111";
+    const caller = "0x3333333333333333333333333333333333333333";
+    const message = renderTelegramMessage(
+      baseAction({
+        kind: "withdrew_from_cooldown",
+        tokenSymbol: "stYFI",
+        user: zeroAddress,
+        owner: account,
+        receiver: account,
+        caller,
+        amounts: {
+          assets: ONE,
+          shares: ONE,
+        },
+      }),
+    );
+
+    expect(message).toContain(
+      "Account: <a href=\"https://etherscan.io/address/0x1111111111111111111111111111111111111111\">",
+    );
+    expect(message).not.toContain(zeroAddress);
+    expect(message).not.toContain("Owner:");
+    expect(message).toContain(
+      "Caller: <a href=\"https://etherscan.io/address/0x3333333333333333333333333333333333333333\">",
+    );
+  });
+
   it("renders upYFI redemption using supYFI labels and fee line", () => {
     const message = renderTelegramMessage(
       baseAction({

--- a/workers/alerts-bot/src/index.ts
+++ b/workers/alerts-bot/src/index.ts
@@ -2440,13 +2440,28 @@ function isStyfiAction(action: NormalizedAction): boolean {
   return normalizedSymbol === "styfi" || normalizedSymbol === "styfix";
 }
 
+function isMalformedStyfiActor(value: string | undefined): boolean {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === UNKNOWN_USER || isZeroAddress(value);
+}
+
 function needsStyfiActorRepair(action: NormalizedAction): boolean {
   if (!isStyfiAction(action)) {
     return false;
   }
 
+  if (action.kind === "withdrew_from_cooldown") {
+    // Withdraw alerts depend on the account-facing owner/receiver tuple, and the
+    // tx calldata is authoritative even when the decoded event attribution is malformed.
+    return true;
+  }
+
   return [action.user, action.owner, action.receiver, action.caller].some(
-    (value) => typeof value === "string" && isZeroAddress(value),
+    (value) => isMalformedStyfiActor(value),
   );
 }
 

--- a/workers/alerts-bot/src/messages.ts
+++ b/workers/alerts-bot/src/messages.ts
@@ -550,9 +550,32 @@ function buildActorLines(
   const lines: string[] = [];
   const seen: string[] = [];
 
-  const user = action.user;
-  const owner = action.owner ?? action.user;
-  const receiver = action.receiver ?? action.user;
+  const isRenderableActor = (value: string | undefined): value is string => {
+    if (typeof value !== "string") {
+      return false;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0 || trimmed.toLowerCase() === "unknown") {
+      return false;
+    }
+
+    return !trimmed.startsWith("0x") || !isZeroAddress(trimmed);
+  };
+
+  const accountCandidates =
+    action.kind === "withdrew_from_cooldown"
+      ? [action.owner, action.receiver, action.user]
+      : [action.user, action.owner, action.receiver];
+  const account =
+    accountCandidates.find((candidate) => isRenderableActor(candidate))?.trim() ?? null;
+  const owner = isRenderableActor(action.owner)
+    ? action.owner.trim()
+    : account ?? undefined;
+  const receiver = isRenderableActor(action.receiver)
+    ? action.receiver.trim()
+    : account ?? undefined;
+  const caller = isRenderableActor(action.caller) ? action.caller.trim() : undefined;
 
   const addLine = (label: string, value: string | undefined): void => {
     if (!value) {
@@ -572,20 +595,24 @@ function buildActorLines(
     lines.push(`${label}: ${buildAddressLink(value, options.ensNamesByAddress)}`);
   };
 
-  if (areSameAddress(user, owner) && areSameAddress(user, receiver)) {
-    addLine("Account", user);
+  if (account && owner && receiver && areSameAddress(account, owner) && areSameAddress(account, receiver)) {
+    addLine("Account", account);
   } else {
-    addLine("Account", user);
-    if (!areSameAddress(owner, user)) {
+    addLine("Account", account ?? undefined);
+    if (owner && (!account || !areSameAddress(owner, account))) {
       addLine("Owner", owner);
     }
-    if (!areSameAddress(receiver, user) && !areSameAddress(receiver, owner)) {
+    if (
+      receiver &&
+      (!account || !areSameAddress(receiver, account)) &&
+      (!owner || !areSameAddress(receiver, owner))
+    ) {
       addLine("Receiver", receiver);
     }
   }
 
-  if (action.caller) {
-    addLine("Caller", action.caller);
+  if (caller) {
+    addLine("Caller", caller);
   }
 
   return lines;


### PR DESCRIPTION
- always reconcile stYFI and stYFIx cooldown-withdraw actors from receipt and tx metadata
- prefer owner or receiver as the visible account when malformed withdraw actor fields leak into rendering
- add scanner and Telegram regressions for withdraw transactions with incorrect decoded actors