### PR TITLE
ci: harden dependency installation and GitHub Actions pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -21,21 +21,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
 
-      - name: Install Dependencies
-        run: npm ci
+      - name: Setup npm
+        env:
+          npm_config_min_release_age: "0"
+        run: npm install --global npm@11.14.0
 
       - name: Validate Dependency Policy
         run: npm run validate:deps
+
+      - name: Configure npm Install Policy
+        run: node ./scripts/configure-npm-install-policy.mjs >> "$GITHUB_ENV"
+
+      - name: Install Dependencies
+        run: npm ci
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/deploy-preprod.yml
+++ b/.github/workflows/deploy-preprod.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: master
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -16,21 +16,29 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: master
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
 
-      - name: Install Dependencies
-        run: npm ci
+      - name: Setup npm
+        env:
+          npm_config_min_release_age: "0"
+        run: npm install --global npm@11.14.0
 
       - name: Validate Dependency Policy
         run: npm run validate:deps
+
+      - name: Configure npm Install Policy
+        run: node ./scripts/configure-npm-install-policy.mjs >> "$GITHUB_ENV"
+
+      - name: Install Dependencies
+        run: npm ci
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/security-and-quality.yml
+++ b/.github/workflows/security-and-quality.yml
@@ -12,19 +12,27 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"
 
-      - name: Install Dependencies
-        run: npm ci
+      - name: Setup npm
+        env:
+          npm_config_min_release_age: "0"
+        run: npm install --global npm@11.14.0
 
       - name: Validate Dependency Policy
         run: npm run validate:deps
+
+      - name: Configure npm Install Policy
+        run: node ./scripts/configure-npm-install-policy.mjs >> "$GITHUB_ENV"
+
+      - name: Install Dependencies
+        run: npm ci
 
       - name: Validate Production Env Invariants
         env:

--- a/.github/workflows/security-and-quality.yml
+++ b/.github/workflows/security-and-quality.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".nvmrc"
           cache: "npm"

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 save-exact=true
 engine-strict=true
+min-release-age=7
 audit=false
 fund=false

--- a/docs/shared/security-hardening.md
+++ b/docs/shared/security-hardening.md
@@ -22,8 +22,11 @@ Operational playbook:
 - Direct dependencies and devDependencies are pinned to exact versions in `/package.json`.
 - Dependency versions must be exact semver specifiers (`x.y.z`, with optional prerelease/build metadata).
 - Non-deterministic specifiers (tags like `latest`, ranges, git URLs, and protocol aliases) are rejected.
-- `packageManager` is pinned to an exact npm version.
+- `packageManager` is pinned to an exact npm version and CI installs that exact npm version before dependency installation.
 - `package-lock.json` is required and must use `lockfileVersion >= 3`.
+- GitHub Actions are pinned to full commit SHAs with same-line version comments so Dependabot can update the SHA and human-readable version together.
+- Packages that declare npm lifecycle install scripts are rejected unless the exact lockfile path and version are allowlisted in `/scripts/validate-dependency-policy.mjs`.
+- Dependabot version updates are enabled for GitHub Actions and npm with a 7-day cooldown.
 
 ### 2.2 Local Install Policy
 
@@ -31,19 +34,62 @@ Operational playbook:
 
 - `save-exact=true`
 - `engine-strict=true`
+- `min-release-age=7`
 - `audit=false`
 - `fund=false`
+
+`ignore-scripts=true` is intentionally not set globally. This app depends on reviewed native/binary packages such as `esbuild`, `sharp`, `workerd`, and `wrangler`, where install scripts perform platform binary selection or validation. New install scripts must be reviewed and allowlisted by exact lockfile path and version instead.
 
 ### 2.3 CI Enforcement
 
 CI workflow `/.github/workflows/security-and-quality.yml` enforces:
 
-- `npm ci` (no floating installs)
 - `npm run validate:deps`
+- configured npm release-age policy
+- `npm ci` (no floating installs)
 - `npm run validate:prod-env`
 - `npm run typecheck`
 - `npm run lint`
 - `npm test`
+
+Deployment workflows apply the same dependency policy before building or deploying workers.
+
+### 2.4 Release-Age Override Path
+
+The default policy rejects package versions published less than 7 days ago. For an urgent security fix that cannot wait for the age window:
+
+1. Manually verify the advisory, upstream release, changelog, and package provenance.
+2. Update the dependency and lockfile with the age gate disabled only for the local command:
+
+```bash
+env npm_config_min_release_age=0 npm install <package>@<version> --save-exact
+```
+
+Use `--save-dev` as well when the override is for a development dependency.
+
+3. Add `.github/npm-release-age-overrides.json` in the same PR:
+
+```json
+{
+  "overrides": [
+    {
+      "package": "<package>",
+      "version": "<version>",
+      "expires": "YYYY-MM-DD",
+      "reason": "Urgent fix for <advisory or incident>",
+      "reference": "https://..."
+    }
+  ]
+}
+```
+
+Rules:
+
+- `expires` must be within 14 days and is checked in UTC.
+- The override must reference a package/version present in `package-lock.json`.
+- CI disables the npm release-age gate only while a non-expired override exists.
+- npm does not currently provide per-package release-age exclusions, so this override disables the age gate for the install run; reviewers must treat the lockfile diff as part of the exception review.
+- Remove the override once the package version is older than 7 days or the emergency is resolved.
 
 ## 3. Production Runtime Invariants
 

--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
   "engines": {
     "node": "24.x"
   },
-  "packageManager": "npm@11.3.0"
+  "packageManager": "npm@11.14.0"
 }

--- a/scripts/configure-npm-install-policy.mjs
+++ b/scripts/configure-npm-install-policy.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const DEFAULT_MIN_RELEASE_AGE_DAYS = 7;
+const overridePath = path.join(ROOT, ".github", "npm-release-age-overrides.json");
+
+function readOverrides() {
+  if (!fs.existsSync(overridePath)) return [];
+  const parsed = JSON.parse(fs.readFileSync(overridePath, "utf8"));
+  return Array.isArray(parsed.overrides) ? parsed.overrides : [];
+}
+
+function endOfUtcDate(dateString) {
+  return new Date(`${dateString}T23:59:59.999Z`);
+}
+
+const now = new Date();
+const activeOverrides = readOverrides().filter((entry) => {
+  if (typeof entry?.expires !== "string") return false;
+  return now <= endOfUtcDate(entry.expires);
+});
+
+if (activeOverrides.length > 0) {
+  const labels = activeOverrides
+    .map((entry) => `${entry.package}@${entry.version} until ${entry.expires}`)
+    .join(", ");
+  console.error(`Using npm release-age override for: ${labels}`);
+  console.log("npm_config_min_release_age=0");
+} else {
+  console.log(`npm_config_min_release_age=${DEFAULT_MIN_RELEASE_AGE_DAYS}`);
+}

--- a/scripts/validate-dependency-policy.mjs
+++ b/scripts/validate-dependency-policy.mjs
@@ -1,10 +1,65 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 
 const ROOT = process.cwd();
 const packageJsonPath = path.join(ROOT, "package.json");
 const packageLockPath = path.join(ROOT, "package-lock.json");
+const npmReleaseAgeOverridePath = path.join(
+  ROOT,
+  ".github",
+  "npm-release-age-overrides.json"
+);
+const maxReleaseAgeOverrideDays = 14;
+const msPerDay = 24 * 60 * 60 * 1000;
+
+const allowedInstallScriptPackages = new Map([
+  [
+    "node_modules/@opennextjs/aws/node_modules/esbuild@0.25.4",
+    "OpenNext AWS adapter uses esbuild's platform binary validation.",
+  ],
+  [
+    "node_modules/bufferutil@4.0.9",
+    "Optional native WebSocket performance helper used by transitive wallet/RPC dependencies.",
+  ],
+  [
+    "node_modules/esbuild@0.21.5",
+    "Build tooling uses esbuild's platform binary validation.",
+  ],
+  [
+    "node_modules/fsevents@2.3.3",
+    "Optional macOS file watcher dependency captured in the lockfile.",
+  ],
+  [
+    "node_modules/keccak@3.0.4",
+    "Ethereum hashing dependency uses a native build helper with JavaScript fallback behavior.",
+  ],
+  [
+    "node_modules/playwright/node_modules/fsevents@2.3.2",
+    "Optional macOS file watcher dependency captured by Playwright.",
+  ],
+  [
+    "node_modules/sharp@0.34.5",
+    "Next.js image pipeline uses sharp's native binary selection.",
+  ],
+  [
+    "node_modules/unrs-resolver@1.11.1",
+    "Resolver package validates its native binding selection after install.",
+  ],
+  [
+    "node_modules/utf-8-validate@5.0.10",
+    "Optional native WebSocket validation helper used by transitive wallet/RPC dependencies.",
+  ],
+  [
+    "node_modules/workerd@1.20260507.1",
+    "Cloudflare worker tooling validates the workerd runtime binary.",
+  ],
+  [
+    "node_modules/wrangler/node_modules/esbuild@0.27.3",
+    "Wrangler uses esbuild's platform binary validation.",
+  ],
+]);
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
@@ -24,6 +79,11 @@ function isExactNpmPackageManager(value) {
   return /^npm@\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(
     normalized
   );
+}
+
+function npmVersionFromPackageManager(value) {
+  if (!isExactNpmPackageManager(value)) return null;
+  return value.trim().slice("npm@".length);
 }
 
 function isAllowedOverrideSpecifier(value) {
@@ -77,6 +137,167 @@ function assertPinnedOverrides(overrides, pathPrefix = "overrides") {
   return violations;
 }
 
+function packageNameFromLockPath(lockPath) {
+  const marker = "node_modules/";
+  const markerIndex = lockPath.lastIndexOf(marker);
+  if (markerIndex === -1) return lockPath;
+
+  const packagePath = lockPath.slice(markerIndex + marker.length);
+  const parts = packagePath.split("/");
+
+  if (parts[0]?.startsWith("@")) {
+    return `${parts[0]}/${parts[1]}`;
+  }
+
+  return parts[0];
+}
+
+function lockPackageKey(lockPath, packageInfo) {
+  return `${lockPath}@${packageInfo.version}`;
+}
+
+function assertAllowedInstallScripts(lock) {
+  if (!lock?.packages || typeof lock.packages !== "object") return [];
+
+  const violations = [];
+  const seenAllowlistedEntries = new Set();
+
+  for (const [lockPath, packageInfo] of Object.entries(lock.packages)) {
+    if (!packageInfo?.hasInstallScript) continue;
+
+    const key = lockPackageKey(lockPath, packageInfo);
+    if (!allowedInstallScriptPackages.has(key)) {
+      const packageName = packageNameFromLockPath(lockPath);
+      violations.push(
+        `${packageName}@${packageInfo.version} declares an install script at ${lockPath}; add a reviewed allowlist entry before merging`
+      );
+      continue;
+    }
+
+    seenAllowlistedEntries.add(key);
+  }
+
+  for (const key of allowedInstallScriptPackages.keys()) {
+    if (!seenAllowlistedEntries.has(key)) {
+      violations.push(
+        `install script allowlist entry is stale or no longer has an install script: ${key}`
+      );
+    }
+  }
+
+  return violations;
+}
+
+function getRunningNpmVersion() {
+  return execFileSync("npm", ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function utcDateStart(date) {
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate()
+  );
+}
+
+function parseUtcDateStart(dateString) {
+  if (typeof dateString !== "string") return Number.NaN;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(dateString)) return Number.NaN;
+  const timestamp = Date.parse(`${dateString}T00:00:00.000Z`);
+  return Number.isNaN(timestamp) ? Number.NaN : timestamp;
+}
+
+function isLockedPackageVersion(lock, packageName, version) {
+  if (!lock?.packages || typeof lock.packages !== "object") return false;
+
+  return Object.entries(lock.packages).some(([lockPath, packageInfo]) => {
+    if (!lockPath.startsWith("node_modules/")) return false;
+    return (
+      packageNameFromLockPath(lockPath) === packageName &&
+      packageInfo?.version === version
+    );
+  });
+}
+
+function assertNpmReleaseAgeOverrides(lock) {
+  if (!fs.existsSync(npmReleaseAgeOverridePath)) return [];
+
+  const violations = [];
+  const parsed = readJson(npmReleaseAgeOverridePath);
+
+  if (
+    parsed === null ||
+    typeof parsed !== "object" ||
+    !Array.isArray(parsed.overrides)
+  ) {
+    return [
+      ".github/npm-release-age-overrides.json must contain an overrides array",
+    ];
+  }
+
+  const today = utcDateStart(new Date());
+  const maxExpiry = today + maxReleaseAgeOverrideDays * msPerDay;
+
+  parsed.overrides.forEach((entry, index) => {
+    const prefix = `release-age override ${index + 1}`;
+
+    if (entry === null || typeof entry !== "object") {
+      violations.push(`${prefix} must be an object`);
+      return;
+    }
+
+    if (typeof entry.package !== "string" || entry.package.trim() === "") {
+      violations.push(`${prefix} must include a package name`);
+    }
+
+    if (!isExactSemverSpecifier(entry.version)) {
+      violations.push(`${prefix} must include an exact semver version`);
+    }
+
+    const expires = parseUtcDateStart(entry.expires);
+    if (Number.isNaN(expires)) {
+      violations.push(`${prefix} must include expires as YYYY-MM-DD`);
+    } else {
+      if (expires < today) {
+        violations.push(`${prefix} expired on ${entry.expires}`);
+      }
+
+      if (expires > maxExpiry) {
+        violations.push(
+          `${prefix} expires more than ${maxReleaseAgeOverrideDays} days from today`
+        );
+      }
+    }
+
+    if (typeof entry.reason !== "string" || entry.reason.trim().length < 12) {
+      violations.push(`${prefix} must include a specific reason`);
+    }
+
+    if (
+      typeof entry.reference !== "string" ||
+      !entry.reference.startsWith("https://")
+    ) {
+      violations.push(`${prefix} must include an https reference URL`);
+    }
+
+    if (
+      typeof entry.package === "string" &&
+      isExactSemverSpecifier(entry.version) &&
+      lock &&
+      !isLockedPackageVersion(lock, entry.package, entry.version)
+    ) {
+      violations.push(
+        `${prefix} references ${entry.package}@${entry.version}, which is not present in package-lock.json`
+      );
+    }
+  });
+
+  return violations;
+}
+
 const pkg = readJson(packageJsonPath);
 const lockExists = fs.existsSync(packageLockPath);
 const lock = lockExists ? readJson(packageLockPath) : null;
@@ -95,8 +316,17 @@ pinViolations.push(...assertPinnedOverrides(pkg.overrides));
 
 if (!isExactNpmPackageManager(pkg.packageManager)) {
   pinViolations.push(
-    "packageManager must be set to an exact npm version (for example: npm@11.3.0)"
+    "packageManager must be set to an exact npm version (for example: npm@11.14.0)"
   );
+} else {
+  const expectedNpmVersion = npmVersionFromPackageManager(pkg.packageManager);
+  const runningNpmVersion = getRunningNpmVersion();
+
+  if (runningNpmVersion !== expectedNpmVersion) {
+    pinViolations.push(
+      `running npm version ${runningNpmVersion} does not match packageManager npm@${expectedNpmVersion}`
+    );
+  }
 }
 
 if (!lockExists) {
@@ -106,6 +336,9 @@ if (!lockExists) {
 if (lock && (typeof lock.lockfileVersion !== "number" || lock.lockfileVersion < 3)) {
   pinViolations.push("package-lock.json must use lockfileVersion >= 3");
 }
+
+pinViolations.push(...assertAllowedInstallScripts(lock));
+pinViolations.push(...assertNpmReleaseAgeOverrides(lock));
 
 if (pinViolations.length > 0) {
   console.error("Dependency policy validation failed:");

--- a/tests/unit/scripts/validate-dependency-policy.test.ts
+++ b/tests/unit/scripts/validate-dependency-policy.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,57 @@ const SCRIPT_PATH = path.resolve(
 );
 
 const createdDirs: string[] = [];
+const runningNpmVersion = spawnSync("npm", ["--version"], {
+  encoding: "utf8",
+}).stdout.trim();
+const exactNpmPackageManager = `npm@${runningNpmVersion}`;
+
+const allowlistedInstallScriptLockPackages = {
+  "node_modules/@opennextjs/aws/node_modules/esbuild": {
+    version: "0.25.4",
+    hasInstallScript: true,
+  },
+  "node_modules/bufferutil": {
+    version: "4.0.9",
+    hasInstallScript: true,
+  },
+  "node_modules/esbuild": {
+    version: "0.21.5",
+    hasInstallScript: true,
+  },
+  "node_modules/fsevents": {
+    version: "2.3.3",
+    hasInstallScript: true,
+  },
+  "node_modules/keccak": {
+    version: "3.0.4",
+    hasInstallScript: true,
+  },
+  "node_modules/playwright/node_modules/fsevents": {
+    version: "2.3.2",
+    hasInstallScript: true,
+  },
+  "node_modules/sharp": {
+    version: "0.34.5",
+    hasInstallScript: true,
+  },
+  "node_modules/unrs-resolver": {
+    version: "1.11.1",
+    hasInstallScript: true,
+  },
+  "node_modules/utf-8-validate": {
+    version: "5.0.10",
+    hasInstallScript: true,
+  },
+  "node_modules/workerd": {
+    version: "1.20260507.1",
+    hasInstallScript: true,
+  },
+  "node_modules/wrangler/node_modules/esbuild": {
+    version: "0.27.3",
+    hasInstallScript: true,
+  },
+};
 
 function createTempRepo(options?: {
   packageManager?: string;
@@ -18,14 +69,20 @@ function createTempRepo(options?: {
   optionalDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   overrides?: Record<string, unknown>;
+  lockPackages?: Record<string, unknown>;
 }) {
   const {
-    packageManager = "npm@11.3.0",
+    packageManager = exactNpmPackageManager,
     dependencies = { foo: "1.0.0" },
     devDependencies = { bar: "2.0.0" },
     optionalDependencies = {},
     peerDependencies = {},
     overrides = {},
+    lockPackages = {
+      "node_modules/foo": { version: "1.0.0" },
+      "node_modules/bar": { version: "2.0.0", dev: true },
+      ...allowlistedInstallScriptLockPackages,
+    },
   } = options ?? {};
   const dir = mkdtempSync(path.join(tmpdir(), "dep-policy-"));
   createdDirs.push(dir);
@@ -55,7 +112,7 @@ function createTempRepo(options?: {
       {
         name: "tmp",
         lockfileVersion: 3,
-        packages: {},
+        packages: lockPackages,
       },
       null,
       2
@@ -63,6 +120,21 @@ function createTempRepo(options?: {
   );
 
   return dir;
+}
+
+function futureDate(daysFromNow: number) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + daysFromNow);
+  return date.toISOString().slice(0, 10);
+}
+
+function writeReleaseAgeOverrides(cwd: string, overrides: unknown[]) {
+  const githubDir = path.join(cwd, ".github");
+  mkdirSync(githubDir, { recursive: true });
+  writeFileSync(
+    path.join(githubDir, "npm-release-age-overrides.json"),
+    JSON.stringify({ overrides }, null, 2)
+  );
 }
 
 function runValidator(cwd: string) {
@@ -81,7 +153,7 @@ afterEach(() => {
 
 describe("validate-dependency-policy", () => {
   it("passes when packageManager pins an exact npm version", () => {
-    const cwd = createTempRepo({ packageManager: "npm@11.3.0" });
+    const cwd = createTempRepo({ packageManager: exactNpmPackageManager });
     const result = runValidator(cwd);
 
     expect(result.status).toBe(0);
@@ -181,5 +253,59 @@ describe("validate-dependency-policy", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Dependency policy validation passed.");
+  });
+
+  it("fails when a locked package declares an unreviewed install script", () => {
+    const cwd = createTempRepo({
+      lockPackages: {
+        "node_modules/foo": { version: "1.0.0" },
+        "node_modules/bar": { version: "2.0.0", dev: true },
+        ...allowlistedInstallScriptLockPackages,
+        "node_modules/surprise-build": {
+          version: "1.2.3",
+          hasInstallScript: true,
+        },
+      },
+    });
+    const result = runValidator(cwd);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "surprise-build@1.2.3 declares an install script"
+    );
+  });
+
+  it("passes with a non-expired release-age override for a locked package", () => {
+    const cwd = createTempRepo();
+    writeReleaseAgeOverrides(cwd, [
+      {
+        package: "foo",
+        version: "1.0.0",
+        expires: futureDate(7),
+        reason: "Urgent security advisory validation",
+        reference: "https://github.com/example/advisory",
+      },
+    ]);
+    const result = runValidator(cwd);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Dependency policy validation passed.");
+  });
+
+  it("fails when a release-age override is expired", () => {
+    const cwd = createTempRepo();
+    writeReleaseAgeOverrides(cwd, [
+      {
+        package: "foo",
+        version: "1.0.0",
+        expires: futureDate(-1),
+        reason: "Urgent security advisory validation",
+        reference: "https://github.com/example/advisory",
+      },
+    ]);
+    const result = runValidator(cwd);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("expired on");
   });
 });


### PR DESCRIPTION
## Summary

Hardens CI and deployment dependency handling by pinning GitHub Actions, enforcing an npm release-age gate, and adding reviewed allowlisting for dependency install scripts.

## Motivation

The previous proposal pinned Actions and disabled npm install scripts globally. We kept the Action pinning, but avoided `ignore-scripts=true` because this repo depends on legitimate binary/native install hooks from packages such as `esbuild`, `sharp`, `workerd`, and `wrangler`.

Instead, this PR uses a reviewed allowlist: new lifecycle install scripts now fail dependency validation unless explicitly reviewed by exact lockfile path and version.

## Changes

- Pin `actions/checkout` and `actions/setup-node` by full commit SHA with exact version comments.
- Add Dependabot coverage for GitHub Actions and npm with 7-day cooldowns.
- Pin npm to `11.14.0` and install that exact npm version in CI before `npm ci`.
- Add `min-release-age=7` to npm install policy.
- Add CI release-age override plumbing for urgent dependency fixes.
- Extend dependency policy validation to:
  - require the running npm version to match `packageManager`
  - reject unreviewed install scripts in `package-lock.json`
  - validate release-age override files for expiry, reason, reference, and lockfile presence
- Document the policy and emergency override path.

## Validation

- `npm ci`
- `npm run validate:deps`
- `npm run validate:prod-env`
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run worker:build`
- `npm run validate:worker-size -- wrangler.preprod.jsonc`
- `npm run validate:worker-size -- wrangler.jsonc`