### PR TITLE
fix(alerts-bot): canonicalize stYFI actor attribution

### DIFF
--- a/tests/unit/workers/alerts-bot.scanner.test.ts
+++ b/tests/unit/workers/alerts-bot.scanner.test.ts
@@ -709,6 +709,117 @@ describe("alerts-bot scanner fixtures", () => {
     });
   });
 
+  it("reconciles stYFIx stake actors from receipt metadata when log actors are wrong but non-zero", async () => {
+    const user = userOf(321);
+    const malformedActor = userOf(322);
+    const txHash = hashOf(3021);
+    const amount = 4_465_182_738_811_854_735n;
+    const zeroAddress = "0x0000000000000000000000000000000000000000" as Address;
+    const logs: RpcLog[] = [
+      createLog({
+        address: STYFIX,
+        topics: encodeEventTopics({
+          abi: ERC4626_DEPOSIT_ABI,
+          eventName: "Deposit",
+          args: { sender: malformedActor, owner: malformedActor },
+        }),
+        data: encodeAbiParameters(
+          [{ type: "uint256" }, { type: "uint256" }],
+          [amount, amount],
+        ),
+        txHash,
+        blockNumber: 63,
+        logIndex: 1,
+      }),
+    ];
+
+    const receiptLogs: RpcLog[] = [
+      createLog({
+        address: STYFI,
+        topics: encodeEventTopics({
+          abi: ERC4626_DEPOSIT_ABI,
+          eventName: "Deposit",
+          args: { sender: STYFIX, owner: STYFIX },
+        }),
+        data: encodeAbiParameters(
+          [{ type: "uint256" }, { type: "uint256" }],
+          [amount, amount],
+        ),
+        txHash,
+        blockNumber: 63,
+        logIndex: 0,
+      }),
+      createLog({
+        address: STYFIX,
+        topics: encodeEventTopics({
+          abi: ERC4626_DEPOSIT_ABI,
+          eventName: "Deposit",
+          args: { sender: user, owner: user },
+        }),
+        data: encodeAbiParameters(
+          [{ type: "uint256" }, { type: "uint256" }],
+          [amount, amount],
+        ),
+        txHash,
+        blockNumber: 63,
+        logIndex: 1,
+      }),
+      createLog({
+        address: STYFIX,
+        topics: encodeEventTopics({
+          abi: ERC20_TRANSFER_ABI,
+          eventName: "Transfer",
+          args: {
+            sender: zeroAddress,
+            receiver: user,
+          },
+        }),
+        data: encodeAbiParameters([{ type: "uint256" }], [amount]),
+        txHash,
+        blockNumber: 63,
+        logIndex: 2,
+      }),
+    ];
+
+    const rpc = createMockRpc({
+      logs,
+      txFromByHash: {
+        [txHash.toLowerCase()]: user,
+      },
+      txToByHash: {
+        [txHash.toLowerCase()]: STYFIX,
+      },
+      txInputByHash: {
+        [txHash.toLowerCase()]: encodeFunctionData({
+          abi: ERC4626_DEPOSIT_CALL_ABI,
+          functionName: "deposit",
+          args: [amount, user],
+        }),
+      },
+      txReceiptByHash: {
+        [txHash.toLowerCase()]: {
+          transactionHash: txHash,
+          blockHash: null,
+          blockNumber: 63,
+          status: 1,
+          logs: receiptLogs,
+        },
+      },
+    });
+
+    const actions = await scanChunkForActions(rpc, 63, 63);
+
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      kind: "staked",
+      tokenSymbol: "stYFIX",
+      user,
+      owner: user,
+      receiver: user,
+      caller: user,
+    });
+  });
+
   it("repairs zero-address stYFI cooldown actors from the tx sender", async () => {
     const user = userOf(33);
     const txHash = hashOf(303);

--- a/workers/alerts-bot/src/index.ts
+++ b/workers/alerts-bot/src/index.ts
@@ -2449,19 +2449,20 @@ function isMalformedStyfiActor(value: string | undefined): boolean {
   return normalized === UNKNOWN_USER || isZeroAddress(value);
 }
 
-function needsStyfiActorRepair(action: NormalizedAction): boolean {
+function shouldCanonicalizeStyfiActors(action: NormalizedAction): boolean {
   if (!isStyfiAction(action)) {
     return false;
   }
 
-  if (action.kind === "withdrew_from_cooldown") {
-    // Withdraw alerts depend on the account-facing owner/receiver tuple, and the
-    // tx calldata is authoritative even when the decoded event attribution is malformed.
-    return true;
-  }
-
-  return [action.user, action.owner, action.receiver, action.caller].some(
-    (value) => isMalformedStyfiActor(value),
+  // stYFI/stYFIx actor fields are cheap to reconcile in batch and tx/receipt
+  // metadata is authoritative even when event actors look superficially valid.
+  return (
+    action.kind === "staked" ||
+    action.kind === "initiated_cooldown" ||
+    action.kind === "withdrew_from_cooldown" ||
+    [action.user, action.owner, action.receiver, action.caller].some((value) =>
+      isMalformedStyfiActor(value),
+    )
   );
 }
 
@@ -2854,7 +2855,7 @@ async function repairStyfiActors(
   const repairableHashes = Array.from(
     new Set(
       actions
-        .filter((action) => needsStyfiActorRepair(action))
+        .filter((action) => shouldCanonicalizeStyfiActors(action))
         .map((action) => action.txHash),
     ),
   );
@@ -2877,7 +2878,7 @@ async function repairStyfiActors(
   });
 
   for (const action of actions) {
-    if (!needsStyfiActorRepair(action)) {
+    if (!shouldCanonicalizeStyfiActors(action)) {
       continue;
     }
 
@@ -2909,7 +2910,7 @@ async function repairStyfiActors(
       previousCaller !== action.caller;
 
     if (changed) {
-      console.warn("Repaired malformed stYFI actor attribution", {
+      console.warn("Canonicalized stYFI actor attribution", {
         txHash: action.txHash,
         kind: action.kind,
         tokenSymbol: action.tokenSymbol,
@@ -3070,7 +3071,8 @@ export async function scanChunkForActionsWithProgress(
       console.warn("Subrequest budget exhausted while repairing stYFI actors", {
         fromBlock,
         toBlock,
-        repairableActions: actions.filter((action) => needsStyfiActorRepair(action)).length,
+        repairableActions: actions.filter((action) => shouldCanonicalizeStyfiActors(action))
+          .length,
         budget: error,
       });
     } else {


### PR DESCRIPTION
- canonicalize stYFI and stYFIx stake, cooldown, and withdraw actors from tx and receipt metadata
- prevent valid-looking but incorrect stake event actors from bypassing reconciliation
- add a regression covering mixed stYFIx deposit receipts with non-zero wrong actors